### PR TITLE
fix vSphere E2E test failures

### DIFF
--- a/.github/workflows/vsphere.yml
+++ b/.github/workflows/vsphere.yml
@@ -56,4 +56,3 @@ jobs:
         with:
           name: vsphere-snapshot-${{matrix.k8s}}-${{matrix.suite}}
           path: artifacts/snapshot.zip
-

--- a/.github/workflows/vsphere.yml
+++ b/.github/workflows/vsphere.yml
@@ -1,25 +1,59 @@
-name: vSphere
+name: E2E vSphere
 
 on:
-  push:
-    branches:
-      - master
-    paths-ignore:
-      - "docs/**"
-
+  schedule:
+    # daily at 00h00 - https://crontab.guru/#0_0_*_*_*
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '0/15 0 * * *'
 jobs:
-  minimal:
-    runs-on: [self-hosted]
-    if: "! contains(toJSON(github.event.commits.*.message), 'skip-e2e')"
+  binary:
+    runs-on: ubuntu-latest
+    container:
+      image: flanksource/build-tools:0.6
     steps:
       - uses: actions/checkout@master
       - run: make pack linux
+      - uses: actions/upload-artifact@v2
+        with:
+          name: karina
+          path: ./.bin/karina
+  test:
+    runs-on: [self-hosted]
+    if: "! contains(toJSON(github.event.commits.*.message), 'skip-e2e')"
+    needs: binary
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s:
+          - v1.16.9
+        suite:
+          - minimal
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/download-artifact@v2
+        with:
+          name: karina
+          path: ./.bin
       - name: Run e2e minimal testing script
+        env:
+          GIT_API_KEY: ${{ secrets.GITHUB_TOKEN }}
+          SUITE: ${{ matrix.suite }}
+          KUBERNETES_VERSION: ${{matrix.k8s}}
+          BUILD: test (${{matrix.k8s}}, ${{ matrix.suite }})
+
         run: |
           # Run the testing commands in subshell with decoded environment
           sops exec-env test/vsphere/lab.enc.env './test/vsphere/e2e.sh'
       - name: Upload test results
+        if: ${{ always() }}
         uses: actions/upload-artifact@v1
         with:
-          name: test-results
+          name: vsphere-test-results-${{matrix.k8s}}-${{matrix.suite}}
           path: test-results/
+      - name: Upload snapshots
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v1
+        with:
+          name: vsphere-snapshot-${{matrix.k8s}}-${{matrix.suite}}
+          path: artifacts/snapshot.zip
+

--- a/.github/workflows/vsphere.yml
+++ b/.github/workflows/vsphere.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # daily at 00h00 - https://crontab.guru/#0_0_*_*_*
     # * is a special character in YAML so you have to quote this string
-    - cron:  '0/15 0 * * *'
+    - cron:  '0 0 * * *'
 jobs:
   binary:
     runs-on: ubuntu-latest

--- a/test/vsphere/e2e.sh
+++ b/test/vsphere/e2e.sh
@@ -6,7 +6,7 @@ mkdir -p .certs
 export TERM=xterm-256color
 REPO=$(basename $(git remote get-url origin | sed 's/\.git//'))
 BIN=.bin/karina
-
+chmod +x $BIN
 
 generate_cluster_id() {
   echo e2e-$(date "+%d%H%M")
@@ -48,11 +48,9 @@ if ! $BIN test  all --e2e --progress=false --junit-path test-results/results.xml
 fi
 
 printf "\n\n\n\n$(tput bold)Reporting$(tput setaf 7)\n"
-wget -nv https://github.com/flanksource/build-tools/releases/download/v0.7.0/build-tools
+wget -nv https://github.com/flanksource/build-tools/releases/download/v0.9.9/build-tools
 chmod +x build-tools
-./build-tools gh report-junit $GITHUB_REPOSITORY $PR_NUM ./test-results/results.xml --auth-token $GIT_API_KEY \
-      --success-message="vSphere minimal tests - commit $COMMIT_SHA" \
-      --failure-message="vSphere minimal tests - :neutral_face: commit $COMMIT_SHA had some failures or skipped tests. **Is it OK?**"
+./build-tools gh actions report-junit test-results/results.xml --token $GIT_API_KEY --build "$BUILD"
 
 mkdir -p artifacts
 $BIN snapshot --output-dir snapshot -v --include-specs=true --include-logs=true --include-events=true $PLATFORM_OPTIONS_FLAGS

--- a/test/vsphere/vsphere.yaml
+++ b/test/vsphere/vsphere.yaml
@@ -47,3 +47,16 @@ vsphere:
   hostname: !!env GOVC_FQDN
   resourcePool: !!env GOVC_RESOURCE_POOL
   network: !!env GOVC_NETWORK
+
+s3:
+  endpoint: http://minio.minio.svc:9000
+  externalEndpoint: minio.127.0.0.1.nip.io
+  bucket: harbor
+  access_key: minio
+  secret_key: minio123
+  region: us-east1
+  kmsMasterKey: minio-demo-key:6368616e676520746869732070617373776f726420746f206120736563726574
+  usePathStyle: true
+  skipTLSVerify: true
+  e2e:
+    minio: false


### PR DESCRIPTION
* switches the trigger event to cron-schedule trigger (**NOTE**: on the default branch workflow),
* aligns workflow with current kind workflow layout (binary step, testing matrix, etc.) to allow for future extension to more scenarios,
* disables minio e2e testing which was failing

closes #395