### PR TITLE
add configurable mapping to teams label

### DIFF
--- a/manifests/kube-resource-report.yaml
+++ b/manifests/kube-resource-report.yaml
@@ -80,6 +80,9 @@ spec:
         - name: kube-resource-report
           # see https://github.com/hjacobs/kube-resource-report/releases
           image: docker.io/hjacobs/kube-resource-report:{{.kubeResourceReport.version | default "20.7.3"}}
+          env:
+            - name: OBJECT_LABEL_TEAM
+              value: "{{.kubeResourceReport.teamlabels | default "team,owner"}}"
           args:
             - --update-interval-minutes={{.kubeResourceReport.updateInterval | default "1"}}
             {{ if .kubeResourceReport.additionalClusterCost  }}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -458,6 +458,11 @@ type KubeResourceReport struct {
 	// the CA for the current cluster needs to be trusted by
 	// the given external cluster.
 	ExternalClusters ExternalClusters `yaml:"extraClusters,omitempty"`
+	// A comma separated list of labels applied to k8s objects
+	// to identify team ownership. These are reported on in the *Teams* tab of the report.
+	// Multiple labels may be specified.
+	// Default value is "team,owner".
+	TeamLabels string `yaml:"teamlabels,omitempty"`
 }
 
 type MonitoringE2E struct {


### PR DESCRIPTION
Allows for the mapping of the labels used to track teams for use in the *Teams* tab.
Default labels are `team` and `owner` (i.e. `"team,owner"`), this PR adds a `kubeResourceReport.teamlabels` config key that allows a comma-separated list to be given to customise the default.

Applying these labels to pods will cause pods to be segmented according to the team specified in the value in the *Teams* tab:

e.g.
with the config

```yaml
kubeResourceReport:
  teamlabels: team,owner,teams-label
```
Any pods labeled `team`, `owner` or `teams-label` will be indicated on the **Teams** tab.
<pre><font color="#8AE234"><i>philip@silent</i></font>:<font color="#729FCF"><i>/code/flanksource/karina-issue-435-kube-resource-report-map-team-labels</i></font>$ kubectl get pods --all-namespaces -l team --show-labels
NAMESPACE   NAME                     READY   STATUS    RESTARTS   AGE   LABELS
quack       quack-6d4b4ddd88-gqjms   1/1     Running   0          8d    app=quack,pod-template-hash=6d4b4ddd88,<b>team=quack</b>
<font color="#8AE234"><i>philip@silent</i></font>:<font color="#729FCF"><i>/code/flanksource/karina-issue-435-kube-resource-report-map-team-labels</i></font>$ kubectl get pods --all-namespaces -l teams-label --show-labels
NAMESPACE      NAME                                       READY   STATUS    RESTARTS   AGE   LABELS
cert-manager   cert-manager-cainjector-67ccfd446f-7llvz   1/1     Running   0          20m   app.kubernetes.io/instance=cert-manager,app.kubernetes.io/name=cainjector,app=cainjector,pod-template-hash=67ccfd446f,<b>teams-label=networks</b>
kube-system    coredns-ccc787c6c-kzb72                    1/1     Running   0          29m   k8s-app=kube-dns,pod-template-hash=ccc787c6c,<b>teams-label=networks</b>
kube-system    coredns-ccc787c6c-w9l9p                    1/1     Running   0          29m   k8s-app=kube-dns,pod-template-hash=ccc787c6c,<b>teams-label=networks</b>
<font color="#8AE234"><i>philip@silent</i></font>:<font color="#729FCF"><i>/code/flanksource/karina-issue-435-kube-resource-report-map-team-labels</i></font>$ kubectl get pods --all-namespaces -l owner --show-labels
NAMESPACE      NAME                            READY   STATUS    RESTARTS   AGE   LABELS
cert-manager   cert-manager-85c6447d48-pmdrd   1/1     Running   0          36m   app.kubernetes.io/instance=cert-manager,app.kubernetes.io/name=cert-manager,app=cert-manager,<b>owner=networks</b>,pod-template-hash=85c6447d48
</pre>
![image](https://user-images.githubusercontent.com/11496482/89720023-748b5480-d9ce-11ea-9fd0-db9ac8689bd9.png)


**NOTE:** 
* it looks like kube-resource-report [only looks at labels](https://github.com/hjacobs/kube-resource-report/blob/7a372a226ec3f3e0a2805d2b43cfdbb618bdb2c9/kube_resource_report/query.py#L257) for determining the team and not annotations.
* pods in system namespaces are ignored in this reporting.

closes #435

