### PR TITLE
Fix quickstart links for Kind and vSphere

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 
 
 ### Getting Started
-To get started provisioning see the quickstart's for [Kind](https://karina.docs.flanksource.com/admin-guide/provisioning/kind.md) and [vSphere](https://karina.docs.flanksource.com/admin-guide/provisioning/vsphere.md) <br>
+To get started provisioning see the quickstart's for [Kind](https://karina.docs.flanksource.com/admin-guide/provisioning/kind/) and [vSphere](https://karina.docs.flanksource.com/admin-guide/provisioning/vsphere/) <br>
 
 ### Production Runtime
 


### PR DESCRIPTION
Going through the `README.md` noticed that quickstarts links were returning `404`. 
This PR changes the link to the correct URL.

Signed-off-by: Tarun Khandelwal <khandelwaltarun32@live.com>