### PR TITLE
Kind cache configure

### DIFF
--- a/pkg/platform/platform.go
+++ b/pkg/platform/platform.go
@@ -512,8 +512,7 @@ func (platform *Platform) Template(file string, pkg string) (string, error) {
 
 func (platform *Platform) GetResourcesByDir(path string, pkg string) (map[string]http.File, error) {
 	out := make(map[string]http.File)
-	var fs http.FileSystem
-	fs = manifests.FS(false)
+	fs := manifests.FS(false)
 	dir, err := fs.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("getResourcesByDir: failed to open fs: %v", err)

--- a/pkg/provision/kind.go
+++ b/pkg/provision/kind.go
@@ -36,8 +36,13 @@ func KindCluster(p *platform.Platform) error {
 		return err
 	}
 
+	cacheDir := os.ExpandEnv("$CACHE_DIR")
+	if cacheDir == "" {
+		cacheDir = os.ExpandEnv("$HOME")
+	}
+
 	for file, content := range files {
-		cache := fmt.Sprintf("%s/.kind/%s%s", os.ExpandEnv("$HOME"), p.Name, file)
+		cache := fmt.Sprintf("%s/.kind/%s%s", cacheDir, p.Name, file)
 		_ = os.MkdirAll(path.Dir(cache), 0755)
 		if err := ioutil.WriteFile(cache, []byte(content), 0644); err != nil {
 			return err


### PR DESCRIPTION
@moshloop Once this merges you should be able to update #506 to export CACHE_DIR=/runner/_work in order for the docker container to see them.