### PR TITLE
Ensure at least one webhook before checking contents

### DIFF
--- a/pkg/phases/opa/install.go
+++ b/pkg/phases/opa/install.go
@@ -150,7 +150,7 @@ func InstallGatekeeper(p *platform.Platform) error {
 	clientset, _ := p.GetClientset()
 	for {
 		webhook, _ := clientset.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(context.TODO(), "gatekeeper-validating-webhook-configuration", metav1.GetOptions{})
-		if webhook != nil && len(webhook.Webhooks[0].ClientConfig.CABundle) > 100 {
+		if webhook != nil && len(webhook.Webhooks) > 0 && len(webhook.Webhooks[0].ClientConfig.CABundle) > 100 {
 			break
 		} else {
 			time.Sleep(3 * time.Second)


### PR DESCRIPTION
Fixes the following error seen in the tests:

panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/flanksource/karina/pkg/phases/opa.InstallGatekeeper(0xc000308800, 0x30d04c0, 0xc000353ac8)
	/__w/karina/karina/pkg/phases/opa/install.go:153 +0xcae
github.com/flanksource/karina/pkg/phases/opa.Install(0xc000308800, 0x0, 0x0)
	/__w/karina/karina/pkg/phases/opa/install.go:25 +0x44
github.com/flanksource/karina/cmd.init.7.func4(0xc0006fadc0, 0xc0006cca20, 0x0, 0x1)
	/__w/karina/karina/cmd/deploy.go:197 +0x204
github.com/spf13/cobra.(*Command).execute(0xc0006fadc0, 0xc0006cca10, 0x1, 0x1, 0xc0006fadc0, 0xc0006cca10)
	/github/home/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:846 +0x29d
github.com/spf13/cobra.(*Command).ExecuteC(0xc0008c78c0, 0x38dbdd5, 0x397, 0xc0000524e0)
	/github/home/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950 +0x349
github.com/spf13/cobra.(*Command).Execute(...)
	/github/home/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
main.main()
	/__w/karina/karina/main.go:108 +0xa70