### PR TITLE
Fix quickstart kind

### DIFF
--- a/docs/admin-guide/provisioning/kind.md
+++ b/docs/admin-guide/provisioning/kind.md
@@ -6,18 +6,18 @@ Download the latest official binary release for your platform from the [github r
 
 #### Linux
 ```bash
-wget https://github.com/flanksource/karina/releases/download/v0.24.4/karina
-chmod +x karina
+wget -nv -nc -O karina https://github.com/flanksource/karina/releases/latest/download/karina && chmod +x karina
 mv karina /usr/local/bin/karina
 ```
 
 #### MacOSX
 ```bash
-wget https://github.com/flanksource/karina/releases/download/v0.24.4/karina_osx
-chmod +x karina_osx
+wget -nv -nc -O karina https://github.com/flanksource/karina/releases/latest/download/karina_osx && chmod +x karina
 mv karina_osx /usr/local/bin/karina
 ```
 
+!!! info
+    For production pipelines you should always pin the version of karina you are using
 
 ### 2) Create a configuration file:
 
@@ -76,8 +76,7 @@ karina deploy all
 ### Cleanup
 Stop and delete the container running Kind with
 ```shell
-docker stop test-cluster-control-plane
-docker rm test-cluster-control-plane
+kind delete cluster --name test-cluster-control-plane
 ```
 
 
@@ -85,7 +84,6 @@ docker rm test-cluster-control-plane
 
 KIND cluster creation issues can be debugged by specifying the `--trace` argument to `karina` during creation:
 
-```Shell
+```shell
 karina provision kind-cluster --trace
 ```
-

--- a/docs/admin-guide/provisioning/kind.md
+++ b/docs/admin-guide/provisioning/kind.md
@@ -4,21 +4,22 @@
 
 Download the latest official binary release for your platform from the [github repository](https://github.com/flanksource/karina/releases/latest).
 
-=== "Linux"
+#### Linux
 ```bash
-wget https://github.com/flanksource/karina/releases/download/v0.15.1/karina
+wget https://github.com/flanksource/karina/releases/download/v0.24.4/karina
 chmod +x karina
 mv karina /usr/local/bin/karina
 ```
-=== "MacOSX"
+
+#### MacOSX
 ```bash
-wget https://github.com/flanksource/karina/releases/download/v0.15.1/karina_osx
+wget https://github.com/flanksource/karina/releases/download/v0.24.4/karina_osx
 chmod +x karina_osx
 mv karina_osx /usr/local/bin/karina
 ```
 
 
-#### 2) Create a configuration file:
+### 2) Create a configuration file:
 
 `test-cluster.yml`
 
@@ -28,7 +29,7 @@ name: test-cluster
 calico:
   version: v3.8.2
 kubernetes:
-  version: v1.16.9
+  version: v1.18.15
   masterIP: localhost
   containerRuntime: containerd
 ca:
@@ -41,7 +42,7 @@ ingressCA:
   password: foobar
 ```
 
-#### 3) Generate the necessary CA's:
+### 3) Generate the necessary CA's:
 
 ```shell
 # generate CA for kubernetes api-server authentication
@@ -52,31 +53,39 @@ karina ca generate --name ingress-ca --cert-path .certs/ingress-ca.crt --private
 
 ```
 
-#### 4) Provision the cluster in kind:
+### 4) Provision the cluster in kind:
 
 ```shell
 karina provision kind-cluster -c test-cluster.yml
 ```
 
-#### 5) Deploy the bare minimum configuration:
+### 5) Deploy the bare minimum configuration:
+This command will deploy following:
+- CRDs for all production runtime defined in the 
 
 ```shell
-karina deploy phases --base --dex --calico -c test-cluster.yml
+karina deploy phases --crds --base --dex --calico -c test-cluster.yml
 ```
 
-#### 6) Deploy everything else that may be configured:
+### 6) Deploy everything else that may be configured:
 
 ```shell
 karina deploy all
 ```
 
+### Cleanup
+Stop and delete the container running Kind with
+```shell
+docker stop test-cluster-control-plane
+docker rm test-cluster-control-plane
+```
 
 
 ## Troubleshooting
 
 KIND cluster creation issues can be debugged by specifying the `--trace` argument to `karina` during creation:
 
-```bash
+```Shell
 karina provision kind-cluster --trace
 ```
 

--- a/manifests/dex.yaml
+++ b/manifests/dex.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: dex
       containers:
-        - image: quay.io/dexidp/dex:{{.dex.version}}
+        - image: ghcr.io/dexidp/dex:{{.dex.version}}
           name: dex
           command: ["/usr/local/bin/dex", "serve", "/etc/dex/cfg/config.yaml"]
           resources:

--- a/pkg/phases/platformoperator/install.go
+++ b/pkg/phases/platformoperator/install.go
@@ -50,7 +50,7 @@ func Install(platform *platform.Platform) error {
 		platform.PlatformOperator.WhitelistedPodAnnotations = []string{}
 	}
 	if platform.PlatformOperator.Version == "" {
-		platform.PlatformOperator.Version = "0.5.1"
+		platform.PlatformOperator.Version = "v0.5.2"
 	}
 
 	if platform.PlatformOperator.Args == nil {


### PR DESCRIPTION
Changes:
- fix: correct the default image tag of `platform-operator` and update to the latest version (`v0.5.2`)
- fix: change dex docker image repo to `ghcr.io/dexidp/dex`
- fix: update Kind Quickstart guide

What did I test:
- Built the latest binary from this branch
- Follow the updated Kind Quickstart guide from this branch
- Confirm all pods in the clusters are started up in healthy state

![image](https://user-images.githubusercontent.com/10015525/107320251-976df280-6a5d-11eb-9ee7-3d6bafac380c.png)

TODO:
- Will need to update the Kind Quickstart again once a new version is released after this PR is merged because the version in the example will not provision a healthy cluster.

Related PRs that can be closed after this is merged: https://github.com/flanksource/karina/pull/663 and https://github.com/flanksource/karina/pull/652

Fixes #651