### PR TITLE
Implement semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,72 +1,41 @@
-name: Release
+name: Create Release
 on:
-  push:
-    tags:
-      - "*"
+  workflow_dispatch: {}
 jobs:
   binary:
     runs-on: ubuntu-latest
     container:
       image: flanksource/build-tools:0.6
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - run: make release
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/upload-artifact@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-        continue-on-error: true
-      - name: Get release
-        id: get_release
-        uses: bruceadams/get-release@v1.2.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: ./.bin/karina
-          asset_name: platform-cli
-          asset_content_type: application/octet-stream
-      - name: Upload MacOSX Release Asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: ./.bin/karina_osx
-          asset_name: platform-cli_osx
-          asset_content_type: application/octet-stream
-      - name: Upload Release Asset2
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: ./.bin/karina
-          asset_name: karina
-          asset_content_type: application/octet-stream
-      - name: Upload MacOSX Release Asset2
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: ./.bin/karina_osx
-          asset_name: karina_osx
-          asset_content_type: application/octet-stream
-  docker:
+          name: karina
+          path: ./.bin/*
+
+  semantic-release:
+    needs: binary
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: karina
+          path: ./.bin
+      - run: ls -R ./.bin
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 12
+      - run: npx semantic-release@17
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker:
+    needs: semantic-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
       - name: Publish to Registry
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
@@ -83,10 +52,12 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           tag_names: true
           snapshot: true
+
   docs:
+    needs: semantic-release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
       - uses: actions/setup-python@v2
       - uses: actions/setup-node@v2

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,9 @@
+plugins:
+  - "@semantic-release/commit-analyzer"
+  - "@semantic-release/release-notes-generator"
+  - - "@semantic-release/github"
+    - assets:
+      - path: ./.bin/karina
+        name: karina
+      - path: ./.bin/karina_osx
+        name: karina_osx

--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -23,7 +23,7 @@ sudo make install # install the executable to /usr/local/bin/
 
 Documentation is done using [MkDocs](https://github.com/mkdocs/mkdocs).
 
-Documentation files are MarkDown formatted text files. These are in the `doc/` hierarchy.
+Documentation files are MarkDown formatted text files. These are in the `docs/` hierarchy.
 
 Run the following to view and edit the documentation locally:
 
@@ -33,7 +33,7 @@ make serve-docs
 
 Navigate to [http://localhost:8000](http://localhost:8000)
 
-Update the documentation sources located in the repository in `doc/` (and its subdirectories) and the mkdocs development server will live-reload the pages as soon as changed.
+Update the documentation sources located in the repository in `docs/` (and its subdirectories) and the mkdocs development server will live-reload the pages as soon as changed.
 
 ## Common Issues
 


### PR DESCRIPTION
### Description

Implemented semantic-release job. This job can be triggered manually for now until we decide to have it run on every commit pushed to master. With this configuration we will have:
- Automatically determine the next version bump of the release based on commits from the last version
- Create tag automatically
- Create GitHub release with correct assets and changelog generated from commits

### Dependencies

- None

### Breaking Change

- [x] No

### Testing Notes

**What I did:**
- Thoroughly tested the workflow in my fork repo. Example of this workflow run: https://github.com/tobernguyen/karina/actions/runs/557301880
- Releases were created with this workflow: https://github.com/tobernguyen/karina/releases

**How you can replicate my testing:**
- Merge this PR
- Go to Repo -> Actions -> Create Release -> Run workflow -> Run workflow from master

### **Links**

Closes https://github.com/flanksource/karina/issues/673
