### PR TITLE
ci: fix create-release not pushing docker tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,9 @@ jobs:
   semantic-release:
     needs: binary
     runs-on: ubuntu-latest
+    outputs:
+      release-version: ${{ steps.semantic.outputs.release-version }}
+      new-release-published: ${{ steps.semantic.outputs.new-release-published }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/download-artifact@v2
@@ -24,15 +27,15 @@ jobs:
           name: karina
           path: ./.bin
       - run: ls -R ./.bin
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 12
-      - run: npx semantic-release@17
+      - uses: codfish/semantic-release-action@v1
+        id: semantic
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   docker:
     needs: semantic-release
+    # Only build/push new docker images when there is new version released
+    if: needs.semantic-release.outputs.new-release-published == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -42,11 +45,10 @@ jobs:
           name: flanksource/karina
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          tag_names: true
           snapshot: true
+          tags: "latest,v${{ needs.semantic-release.outputs.release-version }}"
 
   docs:
-    needs: semantic-release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/pkg/phases/argorollouts/test.go
+++ b/pkg/phases/argorollouts/test.go
@@ -44,7 +44,7 @@ func TestE2E(p *platform.Platform, test *console.TestResults) {
 
 	test.Infof("Checking if Argo Rollouts is working...")
 	client, _ := p.GetClientByKind("Rollout")
-	timeout := 1 * time.Minute
+	timeout := 2 * time.Minute
 	start := time.Now()
 	for {
 		time.Sleep(1 * time.Second)


### PR DESCRIPTION
### Description

Fixes https://github.com/flanksource/karina/issues/698 and add some enhancements:
- Only build and push docker images when there is a new version released from semantic-release.
- Always build docs as we might want to update docs even there are no functional changes.

### Dependencies

- None

### Breaking Change

- [x] No - it fixes stuff

### Testing Notes

**What I did:**
- Trigger "Create release" workflow
- It created a new release on my forked repo
- It pushes docker image with expected tags: latest, snapshot, and the new-released-tag to my dockerhub repo: https://hub.docker.com/repository/docker/tobernguyen/karina
