### PR TITLE
feat: Add default alerts to Canary-Checker deployment

### DIFF
--- a/manifests/canary-checker-alerts.yaml.raw
+++ b/manifests/canary-checker-alerts.yaml.raw
@@ -1,0 +1,26 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: canary-checker-rules
+  namespace: platform-system
+spec:
+  groups:
+    - name: canary-severity
+      rules:
+        - alert: PostgresHeartbeatDown
+          annotations:
+            message: Postgres {{ $labels.exported_endpoint }} is down
+          expr: canary_check{type="postgres"} > 0
+          for: 5m
+          labels:
+            severity: critical
+        - alert: Canary Failing
+          annotations:
+            message: Canary {{ $labels.type }}/{{ $labels.exported_endpoint }} failing for 10m
+          expr: canary_check > 0
+          for: 10m
+          labels:
+            severity: critical

--- a/pkg/phases/canary/deploy.go
+++ b/pkg/phases/canary/deploy.go
@@ -11,11 +11,17 @@ func Deploy(p *platform.Platform) error {
 		if err := p.DeleteSpecs(v1.NamespaceAll, "canary-checker.yaml"); err != nil {
 			p.Errorf("failed to delete specs: %v", err)
 		}
+		if err := p.DeleteSpecs(v1.NamespaceAll, "canary-checker-alerts.yaml.raw"); err != nil {
+			p.Errorf("failed to delete specs: %v", err)
+		}
 		return nil
 	}
 
 	if p.CanaryChecker.Version == "" {
 		p.CanaryChecker.Version = "v0.11.2"
 	}
-	return p.ApplySpecs(v1.NamespaceAll, "canary-checker.yaml")
+	if err := p.ApplySpecs(v1.NamespaceAll, "canary-checker.yaml"); err != nil {
+		return err
+	}
+	return p.ApplySpecs(v1.NamespaceAll, "canary-checker-alerts.yaml.raw")
 }


### PR DESCRIPTION
### Description

Deploy default prometheus alerts that report the state of the canary-checker canaries

### Dependencies

- _Ex. Other PRs._

### Breaking Change

- [ ] Yes
- [ X ] No

### Testing Notes

```
 .bin/karina deploy all -c test/monitoring.yaml
kubectl get prometheusrules --all-namespaces
NAMESPACE         NAME                            AGE
cert-manager      prometheus-cert-manager-rules   67m
monitoring        kubernetes-rules                59m
monitoring        namespace-k8s-rules             59m
monitoring        postgres-rules                  59m
monitoring        prometheus-k8s-rules            59m
platform-system   canary-checker-rules            59m
```

### **Links**
Fixes #703 
