### PR TITLE
feat: add default gatekeeper alerts

### DIFF
--- a/manifests/opa-gatekeeper-monitoring.yaml.raw
+++ b/manifests/opa-gatekeeper-monitoring.yaml.raw
@@ -1,0 +1,61 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: gatekeeper-audit
+  namespace: gatekeeper-system
+spec:
+  selector:
+    matchLabels:
+      control-plane: "audit-controller"
+      gatekeeper.sh/operation: "audit"
+      gatekeeper.sh/system: "yes"
+  namespaceSelector:
+    matchNames:
+      - gatekeeper-system
+  podMetricsEndpoints:
+    - port: metrics
+      interval: 15s
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: gatekeeper
+  namespace: gatekeeper-system
+spec:
+  selector:
+    matchLabels:
+      gatekeeper.sh/system: "yes"
+  namespaceSelector:
+    matchNames:
+      - gatekeeper-system
+  endpoints:
+    - targetPort: 8888
+      interval: 15s
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: prometheus-gatekeeper-rules
+  namespace: gatekeeper-system
+spec:
+  groups:
+  - name: gatekeeper.rules
+    rules:
+      - alert: GatekeeperDenyViolation
+        annotations:
+          message: Gatekeeper deny violations detected, see karina status violations for more info
+        expr: gatekeeper_violations{enforcement_action="deny"} > 0
+        for: 10m
+        labels:
+          severity: critical
+      - alert: GatekeeperDryrunViolation
+        annotations:
+          message: Gatekeeper dryrun violation detected, see karina status violations for more info
+        expr: gatekeeper_violations{enforcement_action="dryrun"} > 0
+        for: 10m
+        labels:
+          severity: warning

--- a/pkg/phases/opa/install.go
+++ b/pkg/phases/opa/install.go
@@ -97,6 +97,9 @@ func InstallGatekeeper(p *platform.Platform) error {
 	if err := p.ApplySpecs(namespace, "opa-gatekeeper.yaml"); err != nil {
 		return err
 	}
+	if err := p.ApplyText(namespace, "opa-gatekeeper-monitoring.yaml.raw"); err != nil {
+		return err
+	}
 
 	p.WaitForNamespace(namespace, 600*time.Second)
 


### PR DESCRIPTION
### Description

Add default alerts to notify if gatekeeper enforcements are active

### Dependencies

NA

### Breaking Change

- [ ] Yes
- [ X ] No

### Testing Notes

Validated pod/servicemonitor config on test cluster
Validated alert logic in PromQL

### **Links**

NA
