### PR TITLE
fix: Use podmonitor rather that servicemonitor for flux scraping

### DIFF
--- a/manifests/flux-monitor.yaml
+++ b/manifests/flux-monitor.yaml
@@ -1,10 +1,8 @@
 apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
+kind: PodMonitor
 metadata:
   name: flux
   namespace: kube-system
-  labels:
-    app: flux
 spec:
   jobLabel: app.kubernetes.io/name
   selector:
@@ -13,8 +11,8 @@ spec:
   namespaceSelector:
     matchNames:
       - kube-system
-  endpoints:
-    - targetPort: 9402
+  podMetricsEndpoints:
+    - targetPort: 3030
       interval: 15s
 ---
 apiVersion: monitoring.coreos.com/v1


### PR DESCRIPTION
### Description

Fix the default flux alert config by moving away from serviceMonitors in favour of podMonitors.  The kommons builder that currently generates the flux service does not have any hooks to add the necessary labels to the service for serviceMonitor to detect

### Dependencies

NA

### Breaking Change

- [ ] Yes
- [ X ] No

### Testing Notes

Deployed manifests/flux-monitor.yaml to running cluster
Verified flux targets came up in prometheus and flux alert metrics were available in promQL browser

### **Links**

NA
