### PR TITLE
chore: bump build env to go1.16 based image

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -15,7 +15,7 @@ jobs:
   binary:
     runs-on: ubuntu-latest
     container:
-      image: flanksource/build-tools:0.6
+      image: flanksource/build-tools:v0.12.0
     steps:
       - uses: actions/checkout@main
       - run: make pack linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ jobs:
   binary:
     runs-on: ubuntu-latest
     container:
-      image: flanksource/build-tools:0.6
+      image: flanksource/build-tools:v0.12.0
     steps:
       - uses: actions/checkout@v2
       - run: make release

--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -15,7 +15,7 @@ jobs:
   binary:
     runs-on: ubuntu-latest
     container:
-      image: flanksource/build-tools:0.6
+      image: flanksource/build-tools:v0.12.0
     steps:
       - uses: actions/checkout@main
       - run: make pack linux

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -15,7 +15,7 @@ jobs:
   binary:
     runs-on: ubuntu-latest
     container:
-      image: flanksource/build-tools:0.6
+      image: flanksource/build-tools:v0.12.0
     steps:
       - uses: actions/checkout@main
       - run: make pack linux

--- a/.github/workflows/vsphere.yml
+++ b/.github/workflows/vsphere.yml
@@ -10,7 +10,7 @@ jobs:
   binary:
     runs-on: ubuntu-latest
     container:
-      image: flanksource/build-tools:0.6
+      image: flanksource/build-tools:v0.12.0
     steps:
       - uses: actions/checkout@master
       - run: make pack linux


### PR DESCRIPTION
### Description

Bump build tools version to ensure go 1.16 is available in the buildenv

### Dependencies

NA

### Breaking Change

- [ ] Yes
- [ X ] No

### Testing Notes

NA, changes to workflows will be checked in workflow results

### **Links**
Fixes #720 
