### PR TITLE
Switch from ESC to Go embed

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -18,7 +18,7 @@ jobs:
       image: flanksource/build-tools:v0.12.0
     steps:
       - uses: actions/checkout@main
-      - run: make pack linux
+      - run: make linux
       - uses: actions/upload-artifact@v2
         with:
           name: karina

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,10 +11,11 @@ jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
+    container:
+      image: flanksource/build-tools:v0.12.0
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
-      - run: make pack
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
@@ -23,9 +24,11 @@ jobs:
         run: go run test/linter/main.go
   docs:
     runs-on: ubuntu-latest
+    container:
+      image: flanksource/build-tools:v0.12.0
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-go@v2
       - uses: actions/setup-python@v2
       - uses: actions/setup-node@v2
-      - run: make pack build-api-docs build-docs
+      - run: make build-api-docs build-docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,6 @@ jobs:
       - uses: actions/setup-go@v2
       - uses: actions/setup-python@v2
       - uses: actions/setup-node@v2
-      - run: make pack build-api-docs build-docs deploy-docs
+      - run: make build-api-docs build-docs deploy-docs
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -18,7 +18,7 @@ jobs:
       image: flanksource/build-tools:v0.12.0
     steps:
       - uses: actions/checkout@main
-      - run: make pack linux
+      - run: make linux
       - uses: actions/upload-artifact@v2
         with:
           name: karina

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -18,7 +18,7 @@ jobs:
       image: flanksource/build-tools:v0.12.0
     steps:
       - uses: actions/checkout@main
-      - run: make pack linux
+      - run: make linux
       - uses: actions/upload-artifact@v2
         with:
           name: karina

--- a/.github/workflows/vsphere.yml
+++ b/.github/workflows/vsphere.yml
@@ -13,7 +13,7 @@ jobs:
       image: flanksource/build-tools:v0.12.0
     steps:
       - uses: actions/checkout@master
-      - run: make pack linux
+      - run: make linux
       - uses: actions/upload-artifact@v2
         with:
           name: karina

--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,6 @@ hack/
 kind
 test-results/
 artifacts/
-manifests/static.go
-templates/static.go
 snapshot/
 vendor/
 .idea

--- a/Makefile
+++ b/Makefile
@@ -23,21 +23,11 @@ help:
 	@cat docs/developer-guide/make-targets.md
 
 .PHONY: release
-release: pack linux darwin compress
+release: linux darwin compress
 
 .PHONY: build
 build:
 	go build -o ./.bin/$(NAME) -ldflags "-X \"main.version=$(VERSION)\""  main.go
-
-ESC := $(shell command -v esc 2> /dev/null)
-
-.PHONY: pack
-pack:
-ifndef ESC
-		wget https://github.com/flanksource/esc/releases/download/v0.2.1/esc && chmod +x esc
-		$(eval ESC=./esc)
-endif
-	$(ESC) --prefix "manifests/" --ignore "static.go" -o manifests/static.go --pkg manifests manifests
 
 .PHONY: linux
 linux:
@@ -86,7 +76,7 @@ deploy-docs:
 	cd docs && make deploy
 
 .PHONY: lint
-lint: pack build
+lint: build
 	golangci-lint run --verbose --print-resources-usage
 
 # Generate code

--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -9,11 +9,15 @@ git clone git@github.com:flanksource/karina.git
 cd karina
 ```
 
+#### Install Go
+
+Karina requires go v1.16 or higher.
+
+#### Compile Karina
+
 Run the following to get going:
 
 ```bash
-make setup        # make sure esc and github-release are installed
-make pack         # pack templates and manifests into go sources
 make              # do a local build
 make compress     # compress the built executable
 sudo make install # install the executable to /usr/local/bin/
@@ -34,16 +38,3 @@ make serve-docs
 Navigate to [http://localhost:8000](http://localhost:8000)
 
 Update the documentation sources located in the repository in `docs/` (and its subdirectories) and the mkdocs development server will live-reload the pages as soon as changed.
-
-## Common Issues
-
-* `build command-line-arguments: cannot load github.com/moshloop/karina/manifests: no matching versions for query "latest"`
-
-You didn't run `make pack` to generate the golang sources embedding the template and manifest files.
-
-Run:
-```sh
-make pack
-```
-
-This generates the `static.go` files in the `manifests/` and `templates/` directories.

--- a/docs/developer-guide/make-targets.md
+++ b/docs/developer-guide/make-targets.md
@@ -3,8 +3,6 @@
 # Make targets
 
 * `help`           - Lists all valid targets
-* `setup`          - Install required dependencies esc and github-release
-* `pack`           - Packs templates and manifests into golang files
 * `build`(default) - Build binaries
 * `install`        - Installs binary locally (needs admin priviliges)
 * `linux`          - Build for Linux
@@ -18,10 +16,8 @@
 
 Normal first time use:
 ```shell
-make setup        # make sure esc and github-release are installed
-make pack         # pack templates and manifests into go sources
 make              # do a local build
 make compress     # compress the built executable
-sudo make install # install the executable to /usr/local/bin/  make pack
+sudo make install # install the executable to /usr/local/bin/
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flanksource/karina
 
-go 1.12
+go 1.16
 
 require (
 	github.com/aws/aws-sdk-go v1.33.18

--- a/manifests/static.go
+++ b/manifests/static.go
@@ -1,0 +1,7 @@
+package manifests
+
+import "embed"
+
+//nolint
+//go:embed *
+var EmbeddedContent embed.FS

--- a/pkg/phases/monitoring/monitoring.go
+++ b/pkg/phases/monitoring/monitoring.go
@@ -106,13 +106,13 @@ func Install(p *platform.Platform) error {
 		}
 	}
 
-	err := deployDashboards(p, "/monitoring/dashboards")
+	err := deployDashboards(p, "monitoring/dashboards")
 	if err != nil {
 		return err
 	}
 
 	if !p.Kubernetes.Managed {
-		err = deployDashboards(p, "/monitoring/dashboards/unmanaged")
+		err = deployDashboards(p, "monitoring/dashboards/unmanaged")
 		if err != nil {
 			return err
 		}

--- a/pkg/phases/nginx/install.go
+++ b/pkg/phases/nginx/install.go
@@ -54,7 +54,7 @@ func Install(platform *platform.Platform) error {
 	}
 
 	if platform.OAuth2Proxy != nil && !platform.OAuth2Proxy.Disabled {
-		scripts, _ := platform.GetResourcesByDir("/nginx", "manifests")
+		scripts, _ := platform.GetResourcesByDir("nginx", "manifests")
 		data := make(map[string]string)
 		for name, file := range scripts {
 			buf := new(bytes.Buffer)

--- a/pkg/phases/opa/install.go
+++ b/pkg/phases/opa/install.go
@@ -98,19 +98,19 @@ func InstallGatekeeper(p *platform.Platform) error {
 	if err := p.ApplySpecs(namespace, "opa-gatekeeper.yaml"); err != nil {
 		return err
 	}
-	if err := p.ApplyText(namespace, "opa-gatekeeper-monitoring.yaml.raw"); err != nil {
+	if err := p.ApplySpecs(namespace, "opa-gatekeeper-monitoring.yaml.raw"); err != nil {
 		return err
 	}
 
 	p.WaitForNamespace(namespace, 600*time.Second)
 
 	if !p.DryRun {
-		defaultConstraints, err := p.GetResourcesByDir("/gatekeeper", "manifests")
+		defaultConstraints, err := p.GetResourcesByDir("gatekeeper", "manifests")
 		if err != nil {
 			return err
 		}
 		for name := range defaultConstraints {
-			constraint, err := p.GetResourceByName("/gatekeeper/"+name, "manifests")
+			constraint, err := p.GetResourceByName("gatekeeper/"+name, "manifests")
 			if err != nil {
 				return err
 			}

--- a/scripts/golint.sh
+++ b/scripts/golint.sh
@@ -2,6 +2,6 @@
 
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.24.0
 
-make pack && make
+make
 mkdir -p test-results
 GOGC=1 golangci-lint run --verbose --print-resources-usage  --out-format=junit-xml > test-results/lint.xml


### PR DESCRIPTION
### Description

Package static content with the go:embed directive rather than esc

### Dependencies

#720 

### Breaking Change

- [ ] Yes
- [ X ] No

No compatibility breaks, but does bump the required version of go to 1.16.  Please update dev environments accordingly

### Testing Notes

Checked Make functions correctly
Checked 'deploy opa' on a kind cluster - opa target uses both static resources by name and by directory.

### **Links**
Fixes #695 
