### PR TITLE
fix: rename conflicting prometheus ruleset

### DIFF
--- a/manifests/monitoring/unmanaged/alertmanager-rules.yaml.raw
+++ b/manifests/monitoring/unmanaged/alertmanager-rules.yaml.raw
@@ -4,7 +4,7 @@ metadata:
   labels:
     prometheus: k8s
     role: alert-rules
-  name: prometheus-k8s-rules
+  name: control-plane-rules
   namespace: monitoring
 spec:
   groups:


### PR DESCRIPTION
### Description

Two separate files both contain the definition for a prometheus ruleset named `prometheus-k8s-rules`.  Renamed the ruleset in the one file to prevent the other being overridden during deployment

### Dependencies

NA

### Breaking Change

- [ ] Yes
- [ X ] No

### Testing Notes

NA

### **Links**

Fixes #733 
