### PR TITLE
chore: set filebeat ssl default to disabled

### DIFF
--- a/manifests/filebeat.yaml
+++ b/manifests/filebeat.yaml
@@ -173,7 +173,7 @@ data:
 {{ else if .logstash }}
     output.logstash:
       hosts: ["${LOGSTASH_URL}"]
-      ssl.verification_mode: none
+      ssl.enabled: false
 {{ end }}
 ---
 {{end}}


### PR DESCRIPTION
### Description

Set the default filebeat logstash config to ssl.enbabled=false

The correct (todo) fix is to expand logstash config and filebeat templating to allow pass ssl settings through to the configmap.

### Dependencies

NA

### Breaking Change

- [ ] Yes
- [ X ] No

### Testing Notes

Verified in working config in customer cluster

### **Links**

NA
