### PR TITLE
fix: update gatekeeper-audit podmonitor labelselector

### DIFF
--- a/manifests/opa-gatekeeper-monitoring.yaml.raw
+++ b/manifests/opa-gatekeeper-monitoring.yaml.raw
@@ -7,7 +7,6 @@ metadata:
 spec:
   selector:
     matchLabels:
-      control-plane: "audit-controller"
       gatekeeper.sh/operation: "audit"
       gatekeeper.sh/system: "yes"
   namespaceSelector:


### PR DESCRIPTION
### Description

Relax a changed label for the podmonitor responsible for picking up violation rules

### Dependencies

NA

### Breaking Change

- [ ] Yes
- [ X ] No

### Testing Notes

Verified podmonitor config in running cluster (Violationcount alert now firing)

### **Links**

N/A