### PR TITLE
Filebeat ssl config

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -224,6 +224,7 @@ AuditConfig is used to specify the audit policy file. If a policy file is specif
 | disabled |  | bool |  |
 | elasticsearch |  | *[Connection](#connection) |  |
 | logstash |  | *[Connection](#connection) |  |
+| ssl | | map[string]interface | |
 
 ## FluentdOperator
 

--- a/manifests/filebeat.yaml
+++ b/manifests/filebeat.yaml
@@ -158,8 +158,7 @@ data:
       username: ${ELASTIC_USERNAME}
       password: ${ELASTIC_PASSWORD}
       protocol: https
-      ssl.verification_mode: none
-      ssl.supported_protocols: [TLSv1.2, TLSv1.3]
+      ssl: '{{ .ssl | default ( coll.Dict "verification_mode" "none" "supported_protocols"  ( coll.Slice "TLSv1.2" "TLSv1.3" )  ) | data.ToJSON }}'
   {{- if ne .index "" }}
       index: "{{ .index }}-%{[agent.version]}-%{+yyyy.MM.dd}"
     setup:
@@ -173,7 +172,7 @@ data:
 {{ else if .logstash }}
     output.logstash:
       hosts: ["${LOGSTASH_URL}"]
-      ssl.verification_mode: none
+      ssl: '{{ .ssl | default ( coll.Dict "enabled" "false" ) | data.ToJSON }}'
 {{ end }}
 ---
 {{end}}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -686,11 +686,12 @@ type ThanosE2E struct {
 
 type Filebeat struct {
 	Disabled      `yaml:",inline" json:",inline"`
-	Name          string      `yaml:"name" json:"name"`
-	Index         string      `yaml:"index" json:"index"`
-	Prefix        string      `yaml:"prefix" json:"prefix"`
-	Elasticsearch *Connection `yaml:"elasticsearch,omitempty" json:"elasticsearch,omitempty"`
-	Logstash      *Connection `yaml:"logstash,omitempty" json:"logstash,omitempty"`
+	Name          string                 `yaml:"name" json:"name"`
+	Index         string                 `yaml:"index" json:"index"`
+	Prefix        string                 `yaml:"prefix" json:"prefix"`
+	Elasticsearch *Connection            `yaml:"elasticsearch,omitempty" json:"elasticsearch,omitempty"`
+	Logstash      *Connection            `yaml:"logstash,omitempty" json:"logstash,omitempty"`
+	SSL           map[string]interface{} `yaml:"ssl,omitempty" json:"ssl,omitempty"`
 }
 
 type Journalbeat struct {


### PR DESCRIPTION
### Description

Add an ssl option to filebeat config

### Dependencies

NA

### Breaking Change

- [ ] Yes
- [ X ] No

### Testing Notes

tested with elastic SUITE:

```
output.elasticsearch:
  hosts: ['${ELASTIC_URL}']
  username: ${ELASTIC_USERNAME}
  password: ${ELASTIC_PASSWORD}
  protocol: https
  ssl: '{"supported_protocols":["TLS1.2","TLS1.3"],"verification_mode":"none"}'
  index: "filebeat-infra-%{[agent.version]}-%{+yyyy.MM.dd}"
  ```

### **Links**

Replaces #756 
