### PR TITLE
fix: set default for elasticsearch persistence

### DIFF
--- a/pkg/phases/elasticsearch/install.go
+++ b/pkg/phases/elasticsearch/install.go
@@ -27,5 +27,13 @@ func Deploy(p *platform.Platform) error {
 		}
 	}
 
+	if p.Elasticsearch.Persistence == nil {
+		p.Elasticsearch.Persistence = &types.Persistence{
+			Enabled:      false,
+			StorageClass: "",
+			Capacity:     "",
+		}
+	}
+
 	return p.ApplySpecs(Namespace, "elasticsearch.yaml")
 }


### PR DESCRIPTION
### Description

Elasticsearch install fails when persistence is not set, due to the  template encountering a nil value rather than a bool.  Set a default value to prevent this

### Dependencies

NA

### Breaking Change

- [ ] Yes
- [ X ] No

### Testing Notes

```
 karina deploy -c test/config.yaml elasticsearch
INFO[0000] Elasticsearch/eck/logs (created) 
INFO[0000] Kibana/eck/logs (created) 
INFO[0000] Ingress/eck/logs-ing (created) 
INFO[0000] Ingress/eck/kibana-ing (created) 
```
on kind cluster with no persistence set in config

### **Links**
NA