### PR TITLE
feat: fail on unrecognized config fields

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
@@ -164,7 +165,11 @@ func mergeConfigBytes(base *types.PlatformConfig, data []byte, path string) erro
 		Source: path,
 	}
 
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	reader := bytes.NewReader(data)
+	decoder := yaml.NewDecoder(reader)
+	decoder.KnownFields(true)
+
+	if err := decoder.Decode(&cfg); err != nil {
 		return errors.Wrap(err, "Failed to parse YAML")
 	}
 

--- a/test/fixtures/unrecognized-fields.yaml
+++ b/test/fixtures/unrecognized-fields.yaml
@@ -1,0 +1,6 @@
+name: test
+domain: 127.0.0.1.nip.io
+kubernetes:
+  version: v1.15.7
+unrecognized:
+  - 1


### PR DESCRIPTION
### Description

Fixes: #700. Causes Karina to fail when encountering unrecognized fields.Not sure if this should be a warn and continue anyway though as it is currently a breaking change.

### Breaking Change

- [x] Yes
- [ ] No