### PR TITLE
feat: add logvolume alert to default prometheus rules

### DIFF
--- a/manifests/monitoring/alertmanager-rules.yaml.raw
+++ b/manifests/monitoring/alertmanager-rules.yaml.raw
@@ -204,6 +204,24 @@ spec:
             cluster:node_cpu_seconds_total:rate5m / count(sum(node_cpu_seconds_total)
             BY (instance, cpu))
           record: cluster:node_cpu:ratio
+    - name: log-count-record
+      interval: 1d
+      rules:
+        - record: average:elastic_documents_by_namespace_cluster_node:1d
+          expr: |
+            sum_over_time(elastic_documents_by_namespace_cluster_node[1d]) / count_over_time(elastic_documents_by_namespace_cluster_node[1d])
+    - name: log-count-alarm
+      rules:
+        - alert: LogVolumeHigh
+          annotations:
+            description: |
+              Namespace {{ $labels.count_namespace }} on node {{ $labels.count_node }} generating logs at double the weekly average rate:
+              {{ printf "elastic_documents_by_namespace_cluster_node{count_namespace='%s', count_node='%s'} .Labels.count_namespace .Labels.count_node" | query | first | value }} > {{ printf "sum_over_time(average:elastic_documents_by_namespace_cluster_node:1d{count_namespace='%s', count_node='%s'}[7d])/count_over_time(average:elastic_documents_by_namespace_cluster_node:1d{count_namespace='%s', count_node='%s'}[7d]) .Labels.count_namespace .Labels.count_node" | query | first | value }}
+          expr: |
+            elastic_documents_by_namespace_cluster_node > 2 * (sum_over_time(average:elastic_documents_by_namespace_cluster_node:1d[7d])/count_over_time(average:elastic_documents_by_namespace_cluster_node:1d[7d]))
+          for: 10m
+          labels:
+            severity: warning
     - name: node-exporter
       rules:
         - alert: NodeFilesystemSpaceFillingUp


### PR DESCRIPTION
### Description

Adds a record of the weekly average log voume, and an alert if the current volume exceeds this by a factor of 2

### Dependencies

NA

### Breaking Change

- [ ] Yes
- [ X ] No

### Testing Notes

Expression logic verified in PromQL

### **Links**

NA
