### PR TITLE
test: use local karina before path karina when testing

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
-if which karina; then
-    BIN=$(which karina)
-else
+if test -f ./.bin/karina; then
     BIN=./.bin/karina
     chmod +x $BIN
-    mkdir -p .bin
+elif command -v karina; then
+    BIN=$(command -v karina)
+else
+    echo "No karina binary detected"
+    exit 127
 fi
+
 export KUBECONFIG=~/.kube/config
 REPO=$(basename $(git remote get-url origin | sed 's/\.git//'))
 GITHUB_OWNER=$(basename $(dirname $(git remote get-url origin | sed 's/\.git//')))

--- a/test/upgrade.sh
+++ b/test/upgrade.sh
@@ -4,13 +4,16 @@ mkdir -p .bin .ref
 REFERENCE_VERSION=${REFERENCE_VERSION:-v0.24.1}
 KUBERNETES_VERSION=${KUBERNETES_VERSION:-v1.18.6}
 SUITE=${SUITE:-minimal}
-if which karina; then
-  BIN=$(which karina)
+if test -f ./.bin/karina; then
+    BIN=./.bin/karina
+    chmod +x $BIN
+elif command -v karina; then
+    BIN=$(command -v karina)
 else
-  BIN=./.bin/karina
-  chmod +x $BIN
-
+    echo "No karina binary detected"
+    exit 127
 fi
+
 REF_BIN=.ref/karina
 
 export KUBECONFIG=~/.kube/config


### PR DESCRIPTION
### Description

Change test logic to use local make output instead of (presumably) stable binary from path

### Dependencies
NA

### Breaking Change

- [ ] Yes
- [ X ] No

### Testing Notes

reran test.sh locally, verified local bin was used for testing

### **Links**

NA
