### PR TITLE
fix: make restic backup optional and backwards compatible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/dghubble/sling v1.3.0
 	github.com/fatih/structs v1.1.0
 	github.com/flanksource/commons v1.5.2
-	github.com/flanksource/kommons v0.11.0
+	github.com/flanksource/kommons v0.11.1
 	github.com/flanksource/konfigadm v0.6.0-2-g9751ff1
 	github.com/flanksource/template-operator-library v0.1.5
 	github.com/go-logr/logr v0.3.0

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v14.2.0+incompatible
 	github.com/flanksource/kommons => github.com/tobernguyen/kommons v0.3.5-0.20210409051250-d6121dbc87ce
-	github.com/flanksource/template-operator-library => github.com/tobernguyen/template-operator-library v0.1.1-0.20210408061816-57964c040f68
+	github.com/flanksource/template-operator-library => github.com/tobernguyen/template-operator-library v0.1.1-0.20210421074316-1ccb09858741
 	github.com/go-check/check v1.0.0-20180628173108-788fd7840127 => github.com/go-check/check v0.0.0-20190902080502-41f04d3bba15
 	github.com/russross/blackfriday v2.0.0+incompatible => github.com/russross/blackfriday v1.5.2
 	golang.org/x/exp => golang.org/x/exp v0.0.0-20190829150108-63fe5bdad115

--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,9 @@ require (
 	github.com/dghubble/sling v1.3.0
 	github.com/fatih/structs v1.1.0
 	github.com/flanksource/commons v1.5.2
-	github.com/flanksource/kommons v0.10.0
+	github.com/flanksource/kommons v0.11.0
 	github.com/flanksource/konfigadm v0.6.0-2-g9751ff1
-	github.com/flanksource/template-operator-library v0.1.0
+	github.com/flanksource/template-operator-library v0.1.5
 	github.com/go-logr/logr v0.3.0
 	github.com/go-logr/zapr v0.3.0 // indirect
 	github.com/go-pg/pg/v9 v9.1.6
@@ -54,8 +54,6 @@ require (
 
 replace (
 	github.com/Azure/go-autorest => github.com/Azure/go-autorest v14.2.0+incompatible
-	github.com/flanksource/kommons => github.com/tobernguyen/kommons v0.3.5-0.20210409051250-d6121dbc87ce
-	github.com/flanksource/template-operator-library => github.com/tobernguyen/template-operator-library v0.1.1-0.20210421074316-1ccb09858741
 	github.com/go-check/check v1.0.0-20180628173108-788fd7840127 => github.com/go-check/check v0.0.0-20190902080502-41f04d3bba15
 	github.com/russross/blackfriday v2.0.0+incompatible => github.com/russross/blackfriday v1.5.2
 	golang.org/x/exp => golang.org/x/exp v0.0.0-20190829150108-63fe5bdad115

--- a/go.sum
+++ b/go.sum
@@ -312,8 +312,13 @@ github.com/fatih/structtag v1.1.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4
 github.com/flanksource/commons v1.5.1/go.mod h1:v76CUuAsGNgF6MYxQ1XJNwQ4N+WSJbsQ+fTILbP4YP0=
 github.com/flanksource/commons v1.5.2 h1:lHAvotmHlr3QzN3r03i2Tm0Q+lZZ/ICm7qa0Bwz/bII=
 github.com/flanksource/commons v1.5.2/go.mod h1:v76CUuAsGNgF6MYxQ1XJNwQ4N+WSJbsQ+fTILbP4YP0=
+github.com/flanksource/kommons v0.10.0/go.mod h1:7tDF0fPqJeRB1dAUI71Mxmdhd0MYaF3YYHdp4XPgIzM=
+github.com/flanksource/kommons v0.11.0 h1:OhbBlD0MOC5HuwyCzoBFWDiUvgYpnc2yWHcGGuxS5zc=
+github.com/flanksource/kommons v0.11.0/go.mod h1:7tDF0fPqJeRB1dAUI71Mxmdhd0MYaF3YYHdp4XPgIzM=
 github.com/flanksource/konfigadm v0.6.0-2-g9751ff1 h1:mPTWZTM0IkiuWmwLX5XJi8TJt5ELm54Qqqq1tMT6r5g=
 github.com/flanksource/konfigadm v0.6.0-2-g9751ff1/go.mod h1:Dt9HKnY/C9WnF8slBm3h9KByogRSiVqARkp1HdSgWjA=
+github.com/flanksource/template-operator-library v0.1.5 h1:9HDGM0mJTh81lR6mLDPmVtFM+FnnBfgLLQaJnlWmEk4=
+github.com/flanksource/template-operator-library v0.1.5/go.mod h1:lo+6i2+nJx4KPa4WHPbxjvuOP1e7vD6HjSHjRvm0OFs=
 github.com/flanksource/yaml v0.0.0-20200325175021-f76146a3718a h1:Q+lJrx9+38jAYnhDJXeapwUXd+j7hh5+sfC5xfnoF9g=
 github.com/flanksource/yaml v0.0.0-20200325175021-f76146a3718a/go.mod h1:9oTOzfyVuHLV9JRt2ZbzdrX2GpYKQk/+mPPXZIYSH6o=
 github.com/flosch/pongo2 v0.0.0-20181225140029-79872a7b2769 h1:XToLChWPMXLomJ2InnkrmUkddaXfevrmomMTFL+MaKU=
@@ -1029,10 +1034,6 @@ github.com/tidwall/pretty v1.0.2/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhV
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc/wtumK+WB441p7ynQJzVuNRJiqddSIE3IlSEQ=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/tobernguyen/kommons v0.3.5-0.20210409051250-d6121dbc87ce h1:uf+g9k1rw0mE0ZiLugEExzhvofdVfwS5wgK9yexKEMw=
-github.com/tobernguyen/kommons v0.3.5-0.20210409051250-d6121dbc87ce/go.mod h1:7tDF0fPqJeRB1dAUI71Mxmdhd0MYaF3YYHdp4XPgIzM=
-github.com/tobernguyen/template-operator-library v0.1.1-0.20210421074316-1ccb09858741 h1:w48wbDoFkLu/HaA0SkoWmD5VA3n7V0jePaNnjlkWv38=
-github.com/tobernguyen/template-operator-library v0.1.1-0.20210421074316-1ccb09858741/go.mod h1:lo+6i2+nJx4KPa4WHPbxjvuOP1e7vD6HjSHjRvm0OFs=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/uber/jaeger-client-go v2.20.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=

--- a/go.sum
+++ b/go.sum
@@ -1031,8 +1031,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tobernguyen/kommons v0.3.5-0.20210409051250-d6121dbc87ce h1:uf+g9k1rw0mE0ZiLugEExzhvofdVfwS5wgK9yexKEMw=
 github.com/tobernguyen/kommons v0.3.5-0.20210409051250-d6121dbc87ce/go.mod h1:7tDF0fPqJeRB1dAUI71Mxmdhd0MYaF3YYHdp4XPgIzM=
-github.com/tobernguyen/template-operator-library v0.1.1-0.20210408061816-57964c040f68 h1:UP6J9WxDzqCB4AlXBx3+mynRomPWLkT/aj4CO8IumeU=
-github.com/tobernguyen/template-operator-library v0.1.1-0.20210408061816-57964c040f68/go.mod h1:0GLzxzhAscZTqfLnpBG+VOP7ldLLMNaSsrXwim83k1E=
+github.com/tobernguyen/template-operator-library v0.1.1-0.20210421074316-1ccb09858741 h1:w48wbDoFkLu/HaA0SkoWmD5VA3n7V0jePaNnjlkWv38=
+github.com/tobernguyen/template-operator-library v0.1.1-0.20210421074316-1ccb09858741/go.mod h1:lo+6i2+nJx4KPa4WHPbxjvuOP1e7vD6HjSHjRvm0OFs=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/uber/jaeger-client-go v2.20.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.2.0+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=

--- a/go.sum
+++ b/go.sum
@@ -313,8 +313,8 @@ github.com/flanksource/commons v1.5.1/go.mod h1:v76CUuAsGNgF6MYxQ1XJNwQ4N+WSJbsQ
 github.com/flanksource/commons v1.5.2 h1:lHAvotmHlr3QzN3r03i2Tm0Q+lZZ/ICm7qa0Bwz/bII=
 github.com/flanksource/commons v1.5.2/go.mod h1:v76CUuAsGNgF6MYxQ1XJNwQ4N+WSJbsQ+fTILbP4YP0=
 github.com/flanksource/kommons v0.10.0/go.mod h1:7tDF0fPqJeRB1dAUI71Mxmdhd0MYaF3YYHdp4XPgIzM=
-github.com/flanksource/kommons v0.11.0 h1:OhbBlD0MOC5HuwyCzoBFWDiUvgYpnc2yWHcGGuxS5zc=
-github.com/flanksource/kommons v0.11.0/go.mod h1:7tDF0fPqJeRB1dAUI71Mxmdhd0MYaF3YYHdp4XPgIzM=
+github.com/flanksource/kommons v0.11.1 h1:Al2dFakb/Y2X4o+fii3RD/YtcHvmZOXDZuzziqhF3sk=
+github.com/flanksource/kommons v0.11.1/go.mod h1:7tDF0fPqJeRB1dAUI71Mxmdhd0MYaF3YYHdp4XPgIzM=
 github.com/flanksource/konfigadm v0.6.0-2-g9751ff1 h1:mPTWZTM0IkiuWmwLX5XJi8TJt5ELm54Qqqq1tMT6r5g=
 github.com/flanksource/konfigadm v0.6.0-2-g9751ff1/go.mod h1:Dt9HKnY/C9WnF8slBm3h9KByogRSiVqARkp1HdSgWjA=
 github.com/flanksource/template-operator-library v0.1.5 h1:9HDGM0mJTh81lR6mLDPmVtFM+FnnBfgLLQaJnlWmEk4=

--- a/manifests/crd/postgresql-db.yaml
+++ b/manifests/crd/postgresql-db.yaml
@@ -20,10 +20,14 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -33,21 +37,9 @@ spec:
                 properties:
                   bucket:
                     type: string
-                  retention:
-                    properties:
-                      keepDaily:
-                        type: integer
-                      keepHourly:
-                        type: integer
-                      keepLast:
-                        type: integer
-                      keepMonthly:
-                        type: integer
-                      keepWeekly:
-                        type: integer
-                      keepYearly:
-                        type: integer
-                    type: object
+                  restic:
+                    default: false
+                    type: boolean
                   schedule:
                     type: string
                 type: object
@@ -73,7 +65,8 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                     type: object
                   requests:
                     additionalProperties:
@@ -82,7 +75,10 @@ spec:
                       - type: string
                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                       x-kubernetes-int-or-string: true
-                    description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                     type: object
                 type: object
               storage:
@@ -91,7 +87,8 @@ spec:
                     description: Size. Required if persistence is enabled
                     type: string
                   storageClass:
-                    description: Storage class to use. If not set default will be used
+                    description: Storage class to use. If not set default will be
+                      used
                     type: string
                 type: object
             type: object
@@ -125,6 +122,122 @@ spec:
         type: object
     served: true
     storage: true
+  - name: v2
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              backup:
+                properties:
+                  bucket:
+                    type: string
+                  restic:
+                    default: true
+                    type: boolean
+                  retention:
+                    properties:
+                      keepDaily:
+                        type: integer
+                      keepHourly:
+                        type: integer
+                      keepLast:
+                        type: integer
+                      keepMonthly:
+                        type: integer
+                      keepWeekly:
+                        type: integer
+                      keepYearly:
+                        type: integer
+                    type: object
+                  schedule:
+                    type: string
+                type: object
+              parameters:
+                additionalProperties:
+                  type: string
+                type: object
+              replicas:
+                type: integer
+              resources:
+                description: ResourceRequirements describes the compute resource requirements.
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                type: object
+              storage:
+                properties:
+                  size:
+                    description: Size. Required if persistence is enabled
+                    type: string
+                  storageClass:
+                    description: Storage class to use. If not set default will be
+                      used
+                    type: string
+                type: object
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastHeartbeatTime:
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+            required:
+            - conditions
+            type: object
+        type: object
+    served: true
+    storage: false
 status:
   acceptedNames:
     kind: ""

--- a/manifests/template/postgresql-db.yaml.raw
+++ b/manifests/template/postgresql-db.yaml.raw
@@ -377,7 +377,8 @@ spec:
       interval: 14400
       s3Bucket:
       - accessKey: $AWS_ACCESS_KEY_ID
-        bucket: '{{.spec.backup.bucket}}'
+        bucket: '{{ .spec.backup.bucket | default (kget "secret/postgres-operator/postgres-operator-cluster-environment"
+          "BACKUP_S3_BUCKET") }}'
         description: '{{.metadata.name}} (backup)'
         endpoint: $AWS_ENDPOINT
         maxAge: 86400

--- a/manifests/template/postgresql-db.yaml.raw
+++ b/manifests/template/postgresql-db.yaml.raw
@@ -71,17 +71,31 @@ spec:
         synchronous_mode: false
         synchronous_mode_strict: false
         ttl: 30
-      podAnnotations: {}
+      podAnnotations:
+        com.flanksource.infra.logs/processors.0.drop_event.when.contains.message: no
+          action.  i am a secondary and i am following a leader
+        com.flanksource.infra.logs/processors.1.drop_event.when.contains.message: no
+          action.  i am the leader with the lock
+        com.flanksource.infra.logs/processors.2.drop_event.when.contains.message: 'INFO:
+          Lock owner:'
+        com.flanksource.infra.logs/processors.3.drop_event.when.contains.message: 'INFO:
+          does not have lock'
+        com.flanksource.infra.logs/processors.4.dissect.tokenizer: '%{date} %{time}
+          %{TZ} [%{PID}] %{user} %{level}: %{log}'
       postgresql:
-        parameters: '{{ .spec.parameters | default (coll.Dict) | data.ToJSON }}'
+        parameters: '{{ (coll.Dict "logging_collector" "false" "log_destination" "stderr"
+          "log_line_prefix" "%m [%p] %q%u@%d " ) | coll.Merge ( .spec.parameters |
+          default (coll.Dict) ) | data.ToJSON }}'
         version: "12"
       resources:
         limits:
           cpu: '{{.spec.resources.limits.cpu | default .spec.cpu | default "1000m"}}'
-          memory: '{{.spec.resources.limits.memory | default .spec.memory | default "512Mi"}}'
+          memory: '{{.spec.resources.limits.memory | default .spec.memory | default
+            "512Mi"}}'
         requests:
           cpu: '{{.spec.resources.requests.cpu | default .spec.cpu |  default "100m"}}'
-          memory: '{{.spec.resources.requests.memory | default .spec.memory  |   default "128Mi"}}'
+          memory: '{{.spec.resources.requests.memory | default .spec.memory  |   default
+            "128Mi"}}'
       serviceAnnotations: {}
       sidecars:
       - env:
@@ -101,7 +115,7 @@ spec:
               name: postgres.postgres-{{.metadata.name}}.credentials
         - name: PG_EXPORTER_EXTEND_QUERY_PATH
           value: /opt/extra-queries/queries.yaml
-        image: docker.io/bitnami/postgres-exporter:0.8.0
+        image: docker.io/bitnami/postgres-exporter:0.9.0
         name: exporter
         ports:
         - containerPort: 9187
@@ -125,24 +139,45 @@ spec:
         storageClass: '{{ .spec.storage.storageClass | default "" }}'
   - apiVersion: v1
     data:
-      AWS_ACCESS_KEY_ID: '{{ kget "secret/postgres-operator/postgres-operator-cluster-environment" "AWS_ACCESS_KEY_ID" }}'
-      AWS_ENDPOINT_URL: '{{ kget "secret/postgres-operator/postgres-operator-cluster-environment" "AWS_ENDPOINT_URL" }}'
-      AWS_REGION: '{{ kget "secret/postgres-operator/postgres-operator-cluster-environment" "AWS_REGION" }}'
-      AWS_SECRET_ACCESS_KEY: '{{ kget "secret/postgres-operator/postgres-operator-cluster-environment" "AWS_SECRET_ACCESS_KEY" }}'
-      BACKUP_IMAGE: '{{ kget "secret/postgres-operator/postgres-operator-cluster-environment" "BACKUP_IMAGE" }}'
-      BACKUP_RETENTION_KEEP_DAILY: '{{ .spec.backup.retention.keepDaily | default (kget "secret/postgres-operator/postgres-operator-cluster-environment" "BACKUP_RETENTION_KEEP_DAILY") }}'
-      BACKUP_RETENTION_KEEP_HOURLY: '{{ .spec.backup.retention.keepHourly | default (kget "secret/postgres-operator/postgres-operator-cluster-environment" "BACKUP_RETENTION_KEEP_HOURLY") }}'
-      BACKUP_RETENTION_KEEP_LAST: '{{ .spec.backup.retention.keepLast | default (kget "secret/postgres-operator/postgres-operator-cluster-environment" "BACKUP_RETENTION_KEEP_LAST") }}'
-      BACKUP_RETENTION_KEEP_MONTHLY: '{{ .spec.backup.retention.keepMonthly | default (kget "secret/postgres-operator/postgres-operator-cluster-environment" "BACKUP_RETENTION_KEEP_MONTHLY") }}'
-      BACKUP_RETENTION_KEEP_WEEKLY: '{{ .spec.backup.retention.keepWeekly | default (kget "secret/postgres-operator/postgres-operator-cluster-environment" "BACKUP_RETENTION_KEEP_WEEKLY") }}'
-      BACKUP_RETENTION_KEEP_YEARLY: '{{ .spec.backup.retention.keepYearly | default (kget "secret/postgres-operator/postgres-operator-cluster-environment" "BACKUP_RETENTION_KEEP_YEARLY") }}'
-      BACKUP_S3_BUCKET: '{{ .spec.backup.bucket | default (kget "secret/postgres-operator/postgres-operator-cluster-environment" "BACKUP_S3_BUCKET") }}'
-      BACKUP_SCHEDULE: '{{ .spec.backup.schedule | default (kget "secret/postgres-operator/postgres-operator-cluster-environment" "BACKUP_SCHEDULE") }}'
-      RESTIC_PASSWORD: '{{ kget "secret/postgres-operator/postgres-operator-cluster-environment" "BACKUP_PASSWORD" }}'
+      AWS_ACCESS_KEY_ID: '{{ kget "secret/postgres-operator/postgres-operator-cluster-environment"
+        "AWS_ACCESS_KEY_ID" }}'
+      AWS_ENDPOINT_URL: '{{ kget "secret/postgres-operator/postgres-operator-cluster-environment"
+        "AWS_ENDPOINT_URL" }}'
+      AWS_REGION: '{{ kget "secret/postgres-operator/postgres-operator-cluster-environment"
+        "AWS_REGION" }}'
+      AWS_SECRET_ACCESS_KEY: '{{ kget "secret/postgres-operator/postgres-operator-cluster-environment"
+        "AWS_SECRET_ACCESS_KEY" }}'
+      BACKUP_IMAGE: '{{ kget "secret/postgres-operator/postgres-operator-cluster-environment"
+        "BACKUP_IMAGE" }}'
+      BACKUP_RETENTION_KEEP_DAILY: '{{ .spec.backup.retention.keepDaily | default
+        (kget "secret/postgres-operator/postgres-operator-cluster-environment" "BACKUP_RETENTION_KEEP_DAILY")
+        }}'
+      BACKUP_RETENTION_KEEP_HOURLY: '{{ .spec.backup.retention.keepHourly | default
+        (kget "secret/postgres-operator/postgres-operator-cluster-environment" "BACKUP_RETENTION_KEEP_HOURLY")
+        }}'
+      BACKUP_RETENTION_KEEP_LAST: '{{ .spec.backup.retention.keepLast | default (kget
+        "secret/postgres-operator/postgres-operator-cluster-environment" "BACKUP_RETENTION_KEEP_LAST")
+        }}'
+      BACKUP_RETENTION_KEEP_MONTHLY: '{{ .spec.backup.retention.keepMonthly | default
+        (kget "secret/postgres-operator/postgres-operator-cluster-environment" "BACKUP_RETENTION_KEEP_MONTHLY")
+        }}'
+      BACKUP_RETENTION_KEEP_WEEKLY: '{{ .spec.backup.retention.keepWeekly | default
+        (kget "secret/postgres-operator/postgres-operator-cluster-environment" "BACKUP_RETENTION_KEEP_WEEKLY")
+        }}'
+      BACKUP_RETENTION_KEEP_YEARLY: '{{ .spec.backup.retention.keepYearly | default
+        (kget "secret/postgres-operator/postgres-operator-cluster-environment" "BACKUP_RETENTION_KEEP_YEARLY")
+        }}'
+      BACKUP_S3_BUCKET: '{{ .spec.backup.bucket | default (kget "secret/postgres-operator/postgres-operator-cluster-environment"
+        "BACKUP_S3_BUCKET") }}'
+      BACKUP_SCHEDULE: '{{ .spec.backup.schedule | default (kget "secret/postgres-operator/postgres-operator-cluster-environment"
+        "BACKUP_SCHEDULE") }}'
+      RESTIC_PASSWORD: '{{ kget "secret/postgres-operator/postgres-operator-cluster-environment"
+        "BACKUP_PASSWORD" }}'
     kind: Secret
     metadata:
       name: backup-postgres-{{ .metadata.name }}-config
       namespace: postgres-operator
+    when: '{{ .spec.backup.restic }}'
   - apiVersion: batch/v1beta1
     kind: CronJob
     metadata:
@@ -183,7 +218,8 @@ spec:
                 envFrom:
                 - secretRef:
                     name: backup-postgres-{{ .metadata.name }}-config
-                image: '{{ kget (print "secret/postgres-operator/backup-postgres-" .metadata.name "-config") "BACKUP_IMAGE" }}'
+                image: '{{ kget (print "secret/postgres-operator/backup-postgres-"
+                  .metadata.name "-config") "BACKUP_IMAGE" }}'
                 imagePullPolicy: IfNotPresent
                 name: backup-postgres-{{.metadata.name}}
                 resources:
@@ -199,9 +235,122 @@ spec:
               restartPolicy: Never
               schedulerName: default-scheduler
               terminationGracePeriodSeconds: 30
-      schedule: '{{ kget (print "secret/postgres-operator/backup-postgres-" .metadata.name "-config") "BACKUP_SCHEDULE" }}'
+      schedule: '{{ kget (print "secret/postgres-operator/backup-postgres-" .metadata.name
+        "-config") "BACKUP_SCHEDULE" }}'
       successfulJobsHistoryLimit: 3
       suspend: false
+    when: '{{ .spec.backup.restic }}'
+  - apiVersion: batch/v1beta1
+    kind: CronJob
+    metadata:
+      name: backup-postgres-{{.metadata.name}}
+      namespace: postgres-operator
+    spec:
+      concurrencyPolicy: Forbid
+      failedJobsHistoryLimit: 1
+      jobTemplate:
+        metadata:
+          creationTimestamp: null
+        spec:
+          template:
+            metadata:
+              creationTimestamp: null
+              labels:
+                application: spilo-logical-backup
+                cluster-name: postgres-{{.metadata.name}}
+            spec:
+              containers:
+              - env:
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      apiVersion: v1
+                      fieldPath: metadata.namespace
+                - name: PGPASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      key: password
+                      name: postgres.postgres-{{.metadata.name}}.credentials
+                - name: PGHOST
+                  value: postgres-{{.metadata.name}}
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: AWS_SECRET_ACCESS_KEY
+                      name: postgres-operator-cluster-environment
+                - name: PGPORT
+                  value: "5432"
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      key: AWS_ACCESS_KEY_ID
+                      name: postgres-operator-cluster-environment
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: AWS_SECRET_ACCESS_KEY
+                      name: postgres-operator-cluster-environment
+                - name: LOGICAL_BACKUP_S3_ENDPOINT
+                  valueFrom:
+                    secretKeyRef:
+                      key: AWS_ENDPOINT_URL
+                      name: postgres-operator-cluster-environment
+                - name: AWS_S3_FORCE_PATH_STYLE
+                  valueFrom:
+                    secretKeyRef:
+                      key: AWS_S3_FORCE_PATH_STYLE
+                      name: postgres-operator-cluster-environment
+                - name: LOGICAL_BACKUP_S3_REGION
+                  valueFrom:
+                    secretKeyRef:
+                      key: AWS_REGION
+                      name: postgres-operator-cluster-environment
+                - name: SCOPE
+                  value: postgres-{{.metadata.name}}
+                - name: PGSSLMODE
+                  value: prefer
+                - name: PGDATABASE
+                  value: postgres
+                - name: LOGICAL_BACKUP_S3_BUCKET
+                  value: '{{.spec.backup.bucket}}'
+                - name: LOGICAL_BACKUP_S3_SSE
+                  value: AES256
+                - name: PG_VERSION
+                  value: "12"
+                - name: PGUSER
+                  value: postgres
+                - name: CLUSTER_NAME_LABEL
+                  value: cluster-name
+                image: docker.io/flanksource/postgres-backups:0.1.5
+                imagePullPolicy: IfNotPresent
+                name: backup-postgres-{{.metadata.name}}
+                ports:
+                - containerPort: 8080
+                  protocol: TCP
+                - containerPort: 5432
+                  protocol: TCP
+                - containerPort: 8008
+                  protocol: TCP
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 512Mi
+                  requests:
+                    cpu: 10m
+                    memory: 128Mi
+                terminationMessagePath: /dev/termination-log
+                terminationMessagePolicy: File
+              dnsPolicy: ClusterFirst
+              restartPolicy: Never
+              schedulerName: default-scheduler
+              securityContext: {}
+              serviceAccount: postgres-pod
+              serviceAccountName: postgres-pod
+              terminationGracePeriodSeconds: 30
+      schedule: '{{.spec.backup.schedule | default "0 2 * * *" }}'
+      successfulJobsHistoryLimit: 3
+      suspend: false
+    when: '{{ not .spec.backup.restic }}'
   - apiVersion: canaries.flanksource.com/v1
     kind: Canary
     metadata:
@@ -228,7 +377,7 @@ spec:
       interval: 14400
       s3Bucket:
       - accessKey: $AWS_ACCESS_KEY_ID
-        bucket: '{{ kget (print "secret/postgres-operator/backup-postgres-" .metadata.name "-config") "LOGICAL_BACKUP_S3_BUCKET" }}'
+        bucket: '{{.spec.backup.bucket}}'
         description: '{{.metadata.name}} (backup)'
         endpoint: $AWS_ENDPOINT
         maxAge: 86400
@@ -237,6 +386,7 @@ spec:
         region: $LOGICAL_BACKUP_S3_REGION
         secretKey: $AWS_SECRET_ACCESS_KEY
         usePathStyle: true
+    when: '{{ not .spec.backup.restic }}'
   - apiVersion: canaries.flanksource.com/v1
     kind: Canary
     metadata:
@@ -257,7 +407,9 @@ spec:
             name: postgres.postgres-{{.metadata.name}}.credentials
       interval: 30
       postgres:
-      - connection: user={{ "{{" }}.username{{ "}}" }} password={{ "{{" }}.password{{ "}}" }} host=postgres-{{.metadata.name}}.postgres-operator port=5432 dbname=postgres sslmode=disable
+      - connection: user={{ "{{" }}.username{{ "}}" }} password={{ "{{" }}.password{{
+          "}}" }} host=postgres-{{.metadata.name}}.postgres-operator port=5432 dbname=postgres
+          sslmode=disable
         description: '{{.metadata.name}} (heartbeat)'
         driver: postgres
         query: SELECT 1

--- a/manifests/upstream/postgresql-db/crd/kustomization.yaml
+++ b/manifests/upstream/postgresql-db/crd/kustomization.yaml
@@ -1,2 +1,2 @@
 resources:
-  - https://raw.githubusercontent.com/tobernguyen/template-operator-library/v0.1.5/config/crd/db/db.flanksource.com_postgresqldbs.yaml
+  - https://raw.githubusercontent.com/flanksource/template-operator-library/v0.1.5/config/crd/db/db.flanksource.com_postgresqldbs.yaml

--- a/manifests/upstream/postgresql-db/crd/kustomization.yaml
+++ b/manifests/upstream/postgresql-db/crd/kustomization.yaml
@@ -1,2 +1,2 @@
 resources:
-  - https://raw.githubusercontent.com/flanksource/template-operator-library/v0.1.3/config/crd/db/db.flanksource.com_postgresqldbs.yaml
+  - https://raw.githubusercontent.com/tobernguyen/template-operator-library/285a95a7d1be6dd35d2a2443106274642725a997/config/crd/db/db.flanksource.com_postgresqldbs.yaml

--- a/manifests/upstream/postgresql-db/crd/kustomization.yaml
+++ b/manifests/upstream/postgresql-db/crd/kustomization.yaml
@@ -1,2 +1,2 @@
 resources:
-  - https://raw.githubusercontent.com/tobernguyen/template-operator-library/285a95a7d1be6dd35d2a2443106274642725a997/config/crd/db/db.flanksource.com_postgresqldbs.yaml
+  - https://raw.githubusercontent.com/tobernguyen/template-operator-library/v0.1.5/config/crd/db/db.flanksource.com_postgresqldbs.yaml

--- a/manifests/upstream/postgresql-db/template/kustomization.yaml
+++ b/manifests/upstream/postgresql-db/template/kustomization.yaml
@@ -1,2 +1,2 @@
 resources:
-  - https://raw.githubusercontent.com/tobernguyen/template-operator-library/5c51efc03808b7286265fd96059997da1f4c1426/config/templates/postgresql-db.yaml
+  - https://raw.githubusercontent.com/tobernguyen/template-operator-library/v0.1.5/config/templates/postgresql-db.yaml

--- a/manifests/upstream/postgresql-db/template/kustomization.yaml
+++ b/manifests/upstream/postgresql-db/template/kustomization.yaml
@@ -1,2 +1,2 @@
 resources:
-  - https://raw.githubusercontent.com/tobernguyen/template-operator-library/v0.1.5/config/templates/postgresql-db.yaml
+  - https://raw.githubusercontent.com/flanksource/template-operator-library/v0.1.5/config/templates/postgresql-db.yaml

--- a/manifests/upstream/postgresql-db/template/kustomization.yaml
+++ b/manifests/upstream/postgresql-db/template/kustomization.yaml
@@ -1,2 +1,2 @@
 resources:
-  - https://raw.githubusercontent.com/flanksource/template-operator-library/v0.1.3/config/templates/postgresql-db.yaml
+  - https://raw.githubusercontent.com/tobernguyen/template-operator-library/5c51efc03808b7286265fd96059997da1f4c1426/config/templates/postgresql-db.yaml

--- a/pkg/client/postgres/tasks.go
+++ b/pkg/client/postgres/tasks.go
@@ -171,7 +171,7 @@ func (db *PostgresDB) ListBackups(s3Bucket string, limit int, quiet bool) ([]str
 			snapshot := resticSnapshots[i]
 			backupPath := sPrintBackupPath(snapshot)
 			backupPaths = append(backupPaths, backupPath)
-			fmt.Fprintf(w, "%s\t%s\t%s\n", backupPath, snapshot.Time.Format("2006-01-01 15:04:05 -07 MST"), text.HumanizeDuration(time.Since(snapshot.Time)))
+			fmt.Fprintf(w, "%s\t%s\t%s\n", backupPath, snapshot.Time.Format("2006-01-02 15:04:05 -07 MST"), text.HumanizeDuration(time.Since(snapshot.Time)))
 		}
 	}
 

--- a/pkg/phases/postgresoperator/test.go
+++ b/pkg/phases/postgresoperator/test.go
@@ -14,7 +14,7 @@ import (
 	pgclient "github.com/flanksource/karina/pkg/client/postgres"
 	"github.com/flanksource/karina/pkg/platform"
 	"github.com/flanksource/kommons"
-	postgresdbv1 "github.com/flanksource/template-operator-library/api/db/v1"
+	postgresdbv2 "github.com/flanksource/template-operator-library/api/db/v2"
 	"github.com/go-pg/pg/v9/orm"
 	"github.com/minio/minio-go/v6"
 	"github.com/pkg/errors"
@@ -143,35 +143,35 @@ func TestLogicalBackupE2E(p *platform.Platform, test *console.TestResults) {
 	test.Passf(testName, "verified test fixtures is in %s after the restore", cluster2ZalandoPsqlName)
 }
 
-func newPostgresqlDBCluster(namespace, name string) *postgresdbv1.PostgresqlDB {
-	return &postgresdbv1.PostgresqlDB{
+func newPostgresqlDBCluster(namespace, name string) *postgresdbv2.PostgresqlDB {
+	return &postgresdbv2.PostgresqlDB{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PostgresqlDB",
-			APIVersion: "db.flanksource.com/v1",
+			APIVersion: "db.flanksource.com/v2",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("e2e-test-%s-%s", utils.RandomString(6), name),
 			Namespace: namespace,
 		},
-		Spec: postgresdbv1.PostgresqlDBSpec{
-			Storage: postgresdbv1.Storage{
+		Spec: postgresdbv2.PostgresqlDBSpec{
+			Storage: postgresdbv2.Storage{
 				Size: "500Mi",
 			},
-			Backup: postgresdbv1.PostgresqlBackup{
+			Backup: postgresdbv2.PostgresqlBackup{
 				Bucket: fmt.Sprintf("logical-backup-test-%s", utils.RandomString(6)),
-				Retention: postgresdbv1.BackupRetention{
+				Retention: postgresdbv2.BackupRetention{
 					KeepLast: 5,
 				},
 			},
 			Replicas: 1,
 		},
-		Status: postgresdbv1.PostgresqlDBStatus{
+		Status: postgresdbv2.PostgresqlDBStatus{
 			Conditions: []v1.Condition{},
 		},
 	}
 }
 
-func removeLogicalBackupE2ECluster(p *platform.Platform, test *console.TestResults, db *postgresdbv1.PostgresqlDB) {
+func removeLogicalBackupE2ECluster(p *platform.Platform, test *console.TestResults, db *postgresdbv2.PostgresqlDB) {
 	client, _, _, err := p.GetDynamicClientFor(Namespace, db)
 	if err != nil {
 		test.Errorf("Failed to get dynamic client: %v", err)

--- a/pkg/phases/postgresoperator/test.go
+++ b/pkg/phases/postgresoperator/test.go
@@ -171,6 +171,7 @@ func newPostgresqlDBCluster(namespace, name string) *postgresdbv2.PostgresqlDB {
 	}
 }
 
+// TODO: replace with platform.WaitForResource
 func waitForPgClusterToReady(p *platform.Platform, namespace, postgresqlClusterName string, timeout time.Duration) error {
 	start := time.Now()
 	db := &pgapi.Postgresql{}

--- a/test/cicd.yaml
+++ b/test/cicd.yaml
@@ -11,7 +11,7 @@ argoRollouts:
 keptn:
   version: v0.7.3
 templateOperator:
-  version: v0.1.10
+  version: v0.1.14
   syncPeriod: 15s
 mongodbOperator:
   version: v1.6.0

--- a/test/postgres.yaml
+++ b/test/postgres.yaml
@@ -1,7 +1,7 @@
 importConfigs:
   - minimal.yaml
 templateOperator:
-  version: v0.1.10
+  version: v0.1.14
   syncPeriod: 15s
 canaryChecker:
   version: v0.15.1


### PR DESCRIPTION
### Description

TODO:
- [x] Need to update go.mod to point to flanksource repo instead of my forked repo after https://github.com/flanksource/template-operator-library/pull/19 is merged

### Dependencies

- https://github.com/flanksource/template-operator/pull/37
- https://github.com/flanksource/template-operator-library/pull/19

### Breaking Change

- [x] Yes - Need to upgrade template-operator to `v0.1.14`

### Testing Notes

**What I did:**
- Build the binary with `make`
- `karina deploy template-operator`
- `karina deploy postgres-operator`
- Deploy 2 PostgresqlDB objects:

`db.yaml`: v1 of PostgresqlDB which disables restic backup by default
```
apiVersion: db.flanksource.com/v1
kind: PostgresqlDB
metadata:
  name: test-db-v1
  namespace: postgres-operator
spec:
  backup:
    bucket: test-pg-backup
    schedule: "*/5 * * * *"
  replicas: 1
  storage:
    size: 1Gi
  parameters:
    archive_mode: "on"
    archive_timeout: 60s
    log_destination: stderr
    max_connections: "600"
    shared_buffers: 2048MB
```

`db-v2.yaml` v2 of PostgresqlDB which enables restic backup by default
```
apiVersion: db.flanksource.com/v2
kind: PostgresqlDB
metadata:
  name: test-db-v2
  namespace: postgres-operator
spec:
  backup:
    bucket: test-pg-backup
    schedule: "*/5 * * * *"
    retention:
      keepLast: 20
      keepDaily: 30
#  cpu: 200m
#  memory: 1Gi
  replicas: 1
  storage:
    size: 1Gi
  parameters:
    archive_mode: "on"
    archive_timeout: 60s
    log_destination: stderr
    max_connections: "600"
    shared_buffers: 2048MB
```
- Confirm that template-operator created:
  - For db.yaml:
    - A CronJob for scheduled backup of `test-db-v1` and use the image: docker.io/flanksource/postgres-backups:0.1.5 (not restic)
    - A Canary for backup of test-db-v1
  - For db-v2.yaml
    - A CronJob for scheduled backup of `test-db-v2` and use the latest image that have restic backup
    - No Canary for backup check for test-db-v2 is deployed

**How you can replicate my testing:**
Same

### **Links**

Closes #800 
