### PR TITLE
ci: use harbor for core images

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -137,6 +137,7 @@ jobs:
           SUITE: ${{ matrix.suite }}
           KUBERNETES_VERSION: ${{matrix.k8s}}
           BUILD: test (${{matrix.k8s}}, ${{ matrix.suite }})
+          ADDITIONAL_CONFIG: -c test/hosted-tests.yaml
         run: ./test/test.sh
       - name: Upload test results
         if: ${{ env.FILE_CHANGES_TO_CORE_ARTIFACTS == 'true' && always() }}

--- a/test/hosted-tests.yaml
+++ b/test/hosted-tests.yaml
@@ -1,0 +1,2 @@
+patches:
+  - ./test/patch1.yaml

--- a/test/minimal.yaml
+++ b/test/minimal.yaml
@@ -2,7 +2,6 @@
 # the kubeconfig cluster name needs to match this name
 name: !!template kind-{{ getenv "SUITE" }}-{{ getenv "KUBERNETES_VERSION" }}
 patches:
-  - ./test/patch1.yaml
   - ./test/templatePatch.yaml
   - |-
     # This ConfigMap is used to verify template

--- a/test/vsphere-harbor.yaml
+++ b/test/vsphere-harbor.yaml
@@ -4,3 +4,33 @@ platformOperator:
 dockerRegistry: harbor.lab.flanksource.com
 kind:
   image: harbor.lab.flanksource.com/docker.io/kindest/node:v1.18.15
+patches:
+  - |-
+     apiVersion: apps/v1
+     kind: Deployment
+     metadata:
+       name: calico-kube-controllers
+       namespace: kube-system
+     spec:
+       template:
+         spec:
+           containers:
+             - name: calico-kube-controllers
+               image: harbor.lab.flanksource.com/docker.io/calico/kube-controllers:{{.calico.version | default "v3.8.2"}}
+  - |-
+     kind: DaemonSet
+     apiVersion: apps/v1
+     metadata:
+       name: calico-node
+       namespace: kube-system
+     spec:
+       template:
+         spec:
+           initContainers:
+             - name: install-cni
+               image: harbor.lab.flanksource.com/docker.io/calico/cni:{{.calico.version | default "v3.8.2"}}
+             - name: flexvol-driver
+               image: harbor.lab.flanksource.com/docker.io/calico/pod2daemon-flexvol:{{.calico.version | default "v3.8.2"}}
+           containers:
+             - name: calico-node
+               image: harbor.lab.flanksource.com/docker.io/calico/node:{{.calico.version | default "v3.8.2"}}

--- a/test/vsphere-harbor.yaml
+++ b/test/vsphere-harbor.yaml
@@ -6,31 +6,47 @@ kind:
   image: harbor.lab.flanksource.com/docker.io/kindest/node:v1.18.15
 patches:
   - |-
-     apiVersion: apps/v1
-     kind: Deployment
-     metadata:
-       name: calico-kube-controllers
-       namespace: kube-system
-     spec:
-       template:
-         spec:
-           containers:
-             - name: calico-kube-controllers
-               image: harbor.lab.flanksource.com/docker.io/calico/kube-controllers:{{.calico.version | default "v3.8.2"}}
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+      labels:
+        k8s-app: calico-kube-controllers
+    spec:
+      template:
+        spec:
+          containers:
+            - name: calico-kube-controllers
+              image: harbor.lab.flanksource.com/docker.io/calico/kube-controllers:v3.8.2
   - |-
-     kind: DaemonSet
-     apiVersion: apps/v1
-     metadata:
-       name: calico-node
-       namespace: kube-system
-     spec:
-       template:
-         spec:
-           initContainers:
-             - name: install-cni
-               image: harbor.lab.flanksource.com/docker.io/calico/cni:{{.calico.version | default "v3.8.2"}}
-             - name: flexvol-driver
-               image: harbor.lab.flanksource.com/docker.io/calico/pod2daemon-flexvol:{{.calico.version | default "v3.8.2"}}
-           containers:
-             - name: calico-node
-               image: harbor.lab.flanksource.com/docker.io/calico/node:{{.calico.version | default "v3.8.2"}}
+    apiVersion: apps/v1
+    kind: DaemonSet
+    metadata:
+      name: calico-node
+      namespace: kube-system
+    spec:
+      template:
+        spec:
+          initContainers:
+            - name: install-cni
+              image: harbor.lab.flanksource.com/docker.io/calico/cni:v3.8.2
+            - name: flexvol-driver
+              image: harbor.lab.flanksource.com/docker.io/calico/pod2daemon-flexvol:v3.8.2
+          containers:
+            - name: calico-node
+              image: harbor.lab.flanksource.com/docker.io/calico/node:v3.8.2
+  - |-
+    apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      name: minio
+      namespace: minio
+      labels:
+        app: minio
+    spec:
+      template:
+        spec:
+          containers:
+            - name: minio
+              image: harbor.lab.flanksource.com/docker.io/minio/minio:RELEASE.2020-03-06T22-23-56Z


### PR DESCRIPTION
### Description

Patch the self-hosted tests to use calico and minio from harbor to prevent docker.io rate limit issues

### Breaking Change

- [ ] Yes
- [x] No