### PR TITLE
fix: ensure 'cloud' is called in phases loop

### DIFF
--- a/pkg/phases/order/order.go
+++ b/pkg/phases/order/order.go
@@ -141,7 +141,7 @@ var PhasesExtra = map[string]DeployFn{
 	"quack":              quack.Install,
 	"template-operator":  templateoperator.Install,
 	"vsphere":            vsphere.Install,
-	"cloud-controller":   Cloud,
+	"cloud":              Cloud,
 	"stubs":              Stubs,
 }
 


### PR DESCRIPTION
### Description

_Short summary of what is the issue and the solution._

Mismatch between `cloud` in the PhaseOrder array and `cloud-controller` at:https://github.com/flanksource/karina/blob/7417b14166e82d646622b25b029d4207611c1470/pkg/phases/order/order.go#L144

### Dependencies

- _Ex. Other PRs._

### Breaking Change

- [x] Yes
- [ ] No

### Testing Notes

Any consumers of `cloud-controller` may have issues, but I don't have enough context to know if this is important. @moshloop?

**What I did:**
_What did you do to validate this PR?_

**How you can replicate my testing:**
_How can the reviewer validate this PR?_

### **Links**

_Issues links or other related resources_
