### PR TITLE
Setup cert-manager certificates for harbor-trivy

### DIFF
--- a/manifests/harbor/core.yaml
+++ b/manifests/harbor/core.yaml
@@ -33,7 +33,7 @@ data:
   CFG_EXPIRATION: "5"
   ADMIRAL_URL: "NA"
   WITH_TRIVY: "true"
-  TRIVY_ADAPTER_URL: "http://harbor-trivy.harbor.svc.cluster.local.:8080"
+  TRIVY_ADAPTER_URL: "https://harbor-trivy.harbor.svc.cluster.local.:8080"
   REGISTRY_STORAGE_PROVIDER_NAME: "s3"
   WITH_CHARTMUSEUM: "true"
   CHART_REPOSITORY_URL: "https://harbor-chartmuseum.harbor.svc.cluster.local."

--- a/manifests/harbor/trivy.yaml
+++ b/manifests/harbor/trivy.yaml
@@ -15,6 +15,20 @@ spec:
     app: "harbor"
     component: trivy
 ---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: trivy-internal-certs
+  namespace: harbor
+spec:
+  secretName: trivy-internal-certs
+  dnsNames:
+    - harbor-trivy
+    - harbor-trivy.harbor.svc.cluster.local.
+  issuerRef:
+    name: default-issuer
+    kind: ClusterIssuer
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -79,6 +93,10 @@ spec:
               value: "false"
             - name: SCANNER_API_SERVER_ADDR
               value: ":8080"
+            - name: SCANNER_API_SERVER_TLS_KEY
+              value: /etc/harbor/ssl/trivy/tls.key
+            - name: SCANNER_API_SERVER_TLS_CERTIFICATE
+              value: /etc/harbor/ssl/trivy/tls.crt
             - name: "SCANNER_REDIS_URL"
               valueFrom:
                 secretKeyRef:
@@ -102,9 +120,11 @@ spec:
             mountPath: /home/scanner/.cache
             subPath: 
             readOnly: false
+          - name: trivy-internal-certs
+            mountPath: /etc/harbor/ssl/trivy
           livenessProbe:
             httpGet:
-              scheme: HTTP
+              scheme: HTTPS
               path: /probe/healthy
               port: api-server
             initialDelaySeconds: 5
@@ -113,7 +133,7 @@ spec:
             failureThreshold: 10
           readinessProbe:
             httpGet:
-              scheme: HTTP
+              scheme: HTTPS
               path: /probe/ready
               port: api-server
             initialDelaySeconds: 5
@@ -127,6 +147,10 @@ spec:
             requests:
               cpu: 200m
               memory: 512Mi
+      volumes:
+        - name: trivy-internal-certs
+          secret:
+            secretName: trivy-internal-certs
   volumeClaimTemplates:
   - metadata:
       name: data


### PR DESCRIPTION
### Description

Add certificates, volumemounts and volume for harbor-trivy

This should be the actual fix for #854 - tracing through the trivy logic leads to https://github.com/aquasecurity/fanal/blob/main/image/image.go#L70 which shows trivy attempts to read the image from a local docker registry via socket, from podman and then from a remote registry.  The third method is the desired usecase in harbor and the error regarding connection to a docker socket is misleading.  The error regarding unknown CA is the actual error, which is addressed here.

### Dependencies

NA

### Breaking Change

- [ ] Yes
- [x] No

### Testing Notes

Applied to kind cluster with harbor2.yaml deployed.

before patch, connection from trivy to harbor core fails:
```
sh-4.4$ curl https://harbor-core.harbor.svc.cluster.local.:443/v2/
curl: (60) SSL certificate problem: unable to get local issuer certificate
More details here: https://curl.haxx.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```
After patch:
```
sh-4.4$ curl https://harbor-core.harbor.svc.cluster.local.:443/v2/
{"errors":[{"code":"UNAUTHORIZED","message":"unauthorized: unauthorized"}]}
```

### **Links**

Fixes #854 
