### PR TITLE
Sealed secrets monitoring

### DIFF
--- a/manifests/monitoring/alertmanager-rules.yaml.raw
+++ b/manifests/monitoring/alertmanager-rules.yaml.raw
@@ -975,3 +975,13 @@ spec:
           for: 5m
           labels:
             severity: warning
+    - name: sealed-secrets
+      rules:
+        - alert: SecretUnsealError
+          annotations:
+            message: A sealed secret in {{ $labels.namespace }} namespace cannot unseal correctly
+          expr: |
+            increase(sealed_secrets_controller_unseal_errors_total[1d]) > 1
+          for: 1m
+          labels:
+            severity: warning

--- a/manifests/sealed-secrets.yaml
+++ b/manifests/sealed-secrets.yaml
@@ -88,9 +88,33 @@ spec:
   ports:
     - port: 8080
       targetPort: 8080
+      name: http
   selector:
     name: sealed-secrets-controller
   type: ClusterIP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: sealed-secrets
+  namespace: sealed-secrets
+  labels:
+    name: sealed-secrets-controller
+spec:
+  endpoints:
+    - interval: 10s
+      scrapeTimeout: 10s
+      honorLabels: true
+      port: http
+      path: /metrics
+      scheme: http
+  jobLabel: "mgmt"
+  selector:
+    matchLabels:
+      name: sealed-secrets-controller
+    namespaceSelector:
+      matchNames:
+        - sealed-secrets
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/test/security.yaml
+++ b/test/security.yaml
@@ -40,7 +40,7 @@ ldap:
 oauth2Proxy:
   version: "v6.1.1"
 sealedSecrets:
-  version: "v0.10.0"
+  version: "v0.15.0"
   certificate:
     cert: .certs/sealed-secrets-crt.pem
     privateKey: .certs/sealed-secrets-key.pem


### PR DESCRIPTION
### Description

Update sealed secrets used in test environment to 1.5
Add sealed secrets servicemonitor
Add sealed secrets alert

### Dependencies

Requires sealedsecrets controller > 1.2

### Breaking Change

- [ ] Yes
- [x] No

### Testing Notes

Deployed into kind cluster, created faulty sealed secret, verified alert appears in prometheus

### **Links**
Fixes #844 
