### PR TITLE
Add IngressClass for nginx ingress

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -110,17 +110,6 @@ jobs:
           - nosql
           - cicd
           - kpack
-        include:
-          - k8s: v1.17.5
-            suite: minimal
-          - k8s: v1.17.5
-            suite: minimal-antrea
-          - k8s: v1.17.5
-            suite: monitoring
-          - k8s: v1.16.9
-            suite: minimal
-          - k8s: v1.16.9
-            suite: monitoring
     steps:
       - uses: actions/checkout@main
         if: ${{ env.FILE_CHANGES_TO_CORE_ARTIFACTS == 'true' }}
@@ -175,13 +164,6 @@ jobs:
           - v1.18.6
         suite:
           - minimal
-        include:
-          - k8s: v1.17.5
-            suite: minimal
-          - k8s: v1.17.5
-            suite: minimal-antrea
-          - k8s: v1.17.5
-            suite: monitoring
     steps:
       - uses: actions/checkout@main
       - uses: actions/download-artifact@v2
@@ -243,17 +225,6 @@ jobs:
           - platform
           # - nosql
           # - cicd
-        # include:
-        #   - k8s: v1.17.5
-        #     suite: minimal
-        #   - k8s: v1.17.5
-        #     suite: minimal-antrea
-        #   - k8s: v1.17.5
-        #     suite: monitoring
-        #   - k8s: v1.16.9
-        #     suite: minimal
-        #   - k8s: v1.16.9
-        #     suite: monitoring
     steps:
       - uses: actions/checkout@main
       - uses: actions/download-artifact@v2

--- a/manifests/nginx.yaml
+++ b/manifests/nginx.yaml
@@ -478,3 +478,12 @@ spec:
   selector:
     matchLabels:
       app: ingress-nginx
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: IngressClass
+metadata:
+  name: nginx
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
+spec:
+  controller: k8s.io/ingress-nginx


### PR DESCRIPTION
### Description

Fixes errors like: `Translation failed: invalid ingress spec: service "uat/clearbank" is type "ClusterIP", expected "NodePort" or "LoadBalancer"`

### Breaking Change

- [ ] Yes
- [x] No