### PR TITLE
feat: split logvolume alerts into node and namespace specific alerts

### DIFF
--- a/manifests/monitoring/alertmanager-rules.yaml.raw
+++ b/manifests/monitoring/alertmanager-rules.yaml.raw
@@ -207,18 +207,35 @@ spec:
     - name: log-count-record
       interval: 1d
       rules:
-        - record: average:elastic_documents_by_namespace_cluster_node:1d
+        - record: elastic_documents_by_namespace_cluster
+          expr: sum (elastic_documents_by_namespace_cluster_node) by (count_namespace, count_cluster)
+        - record: elastic_documents_by_node_cluster
+          expr: sum (elastic_documents_by_namespace_cluster_node) by (count_node, count_cluster)
+        - record: average:elastic_documents_by_namespace_cluster:1d
           expr: |
-            sum_over_time(elastic_documents_by_namespace_cluster_node[1d]) / count_over_time(elastic_documents_by_namespace_cluster_node[1d])
+            sum_over_time(elastic_documents_by_namespace_cluster[1d]) / count_over_time(elastic_documents_by_namespace_cluster[1d])
+        - record: average:elastic_documents_by_node_cluster:1d
+          expr: |
+            sum_over_time(elastic_documents_by_node_cluster[1d]) / count_over_time(elastic_documents_by_node_cluster[1d])
     - name: log-count-alarm
       rules:
-        - alert: LogVolumeHigh
+        - alert: NodeLogVolumeHigh
           annotations:
             description: |
-              Namespace {{ $labels.count_namespace }} on node {{ $labels.count_node }} generating logs at double the weekly average rate:
-              {{ printf "elastic_documents_by_namespace_cluster_node{count_namespace='%s', count_node='%s'} Labels.count_namespace Labels.count_node" | query | first | value }} > {{ printf "sum_over_time(average:elastic_documents_by_namespace_cluster_node:1d{count_namespace='%s', count_node='%s'}[7d])/count_over_time(average:elastic_documents_by_namespace_cluster_node:1d{count_namespace='%s', count_node='%s'}[7d]) Labels.count_namespace Labels.count_node Labels.count_namespace Labels.count_node" | query | first | value }}
+              Node {{ $labels.count_node }} generating logs at double the weekly average rate:
+              {{ printf "elastic_documents_by_node_cluster{count_node='%s'} Labels.count_node" | query | first | value }} > {{ printf "sum_over_time(average:elastic_documents_by_node_cluster:1d{count_node='%s'}[7d])/count_over_time(average:elastic_documents_by_node_cluster:1d{count_node='%s'}[7d]) Labels.count_node Labels.count_node" | query | first | value }
           expr: |
-            elastic_documents_by_namespace_cluster_node > 2 * (sum_over_time(average:elastic_documents_by_namespace_cluster_node:1d[7d])/count_over_time(average:elastic_documents_by_namespace_cluster_node:1d[7d]))
+            elastic_documents_by_node_cluster > 2 * (sum_over_time(average:elastic_documents_by_node_cluster:1d[7d])/count_over_time(average:elastic_documents_by_node_cluster:1d[7d]))
+          for: 10m
+          labels:
+            severity: warning
+        - alert: NamespaceLogVolumeHigh
+          annotations:
+            description: |
+              Node {{ $labels.count_namespace }} generating logs at double the weekly average rate:
+              {{ printf "elastic_documents_by_namespace_cluster{count_namespace='%s'} Labels.count_namespace" | query | first | value }} > {{ printf "sum_over_time(average:elastic_documents_by_namespace_cluster:1d{count_namespace='%s'}[7d])/count_over_time(average:elastic_documents_by_namespace_cluster:1d{count_namespace='%s'}[7d]) Labels.count_namespace Labels.count_namespace" | query | first | value }
+          expr: |
+            elastic_documents_by_namespace_cluster > 2 * (sum_over_time(average:elastic_documents_by_namespace_cluster:1d[7d])/count_over_time(average:elastic_documents_by_namespace_cluster:1d[7d]))
           for: 10m
           labels:
             severity: warning


### PR DESCRIPTION
### Description

generate new prometheus rules to split log volume alerts

### Dependencies

- _Ex. Other PRs._

### Breaking Change

- [ ] Yes
- [X] No

### Testing Notes
Verified promql

### **Links**

