### PR TITLE
fix: correctly choose between decode and decrypt

### DIFF
--- a/pkg/ca/ca.go
+++ b/pkg/ca/ca.go
@@ -36,7 +36,7 @@ func ReadCA(ca *types.CA) (*certs.Certificate, error) {
 		return nil, fmt.Errorf("unable to read private key %s", ca.PrivateKey)
 	}
 
-	if privateKey == "" {
+	if ca.Password == "" {
 		return certs.DecodeCertificate([]byte(cert), []byte(privateKey))
 	}
 	return certs.DecryptCertificate([]byte(cert), []byte(privateKey), []byte(ca.Password))


### PR DESCRIPTION
### Description

Check if password is empty rather than key when chosing betweeen decode and decrypt

### Dependencies

- _Ex. Other PRs._

### Breaking Change

- [ ] Yes
- [x] No

### Testing Notes

**What I did:**
_What did you do to validate this PR?_

**How you can replicate my testing:**
_How can the reviewer validate this PR?_

### **Links**

_Issues links or other related resources_
