### PR TITLE
chore: remove dummy cert from eck manifest

### DIFF
--- a/manifests/eck.yaml
+++ b/manifests/eck.yaml
@@ -251,9 +251,3 @@ spec:
       targetPort: 9443
   selector:
     control-plane: elastic-operator
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: elastic-webhook-server-cert
-  namespace: elastic-system


### PR DESCRIPTION
### Description

The cert in the eck is a dummy to trigger deletion if eck is switched to disabled.  It is often a failure point in deployments that use elasticsearch, with `the object has been modified` errors

### Dependencies

- _Ex. Other PRs._

### Breaking Change

- [ ] Yes
- [x] No

### Testing Notes

**What I did:**
_What did you do to validate this PR?_

**How you can replicate my testing:**
_How can the reviewer validate this PR?_

### **Links**

_Issues links or other related resources_
