### PR TITLE
feat: set packetbeat dns policy

### DIFF
--- a/manifests/packetbeat.yaml
+++ b/manifests/packetbeat.yaml
@@ -86,6 +86,7 @@ spec:
           operator: Exists
       terminationGracePeriodSeconds: 30
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: packetbeat
           image: docker.elastic.co/beats/packetbeat:{{ .packetbeat.version | default "none" }}


### PR DESCRIPTION
### Description

Change packetbeat pod dns policy to be able to use svc addresses

### Dependencies

NA

### Breaking Change

- [ ] Yes
- [x] No

### Testing Notes

NA
