### PR TITLE
Fix version command to display version tag #896

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,9 +12,9 @@ import (
 )
 
 var (
-	version = "dev"
-	commit  = "none"
-	date    = "unknown"
+	version = ""
+	commit  = ""
+	date    = ""
 )
 
 func main() {
@@ -64,10 +64,12 @@ func main() {
 		cmd.Upgrade,
 		cmd.Vault,
 	)
-
 	if len(commit) > 8 {
-		version = fmt.Sprintf("%v, commit %v, built at %v", version, commit[0:8], date)
+		version = fmt.Sprintf("%v-%v-%v", commit[0:8], version, date)
+	} else {
+		version = fmt.Sprintf("%v-%v", version, date)
 	}
+
 	root.AddCommand(&cobra.Command{
 		Use:   "version",
 		Short: "Print the version of karina",


### PR DESCRIPTION
Issue https://github.com/flanksource/karina/issues/896 fix.

### Description

'karina version' command displays only timestamp. Print version tag and commit
if commit exists, with timestamp.

### Dependencies

- _Ex. Other PRs._

### Breaking Change

- [ ] Yes
- [x] No

### Testing Notes

**What I did:**
Built an image using Dockerfile.fast 

**How you can replicate my testing:**
Go binary build command example:

`GOOS=linux GOARCH=amd64 go build -v -o ./.bin/static/karina -mod=vendor -ldflags "-X 'main.version=v45.0' -X 'main.date=20210405133333' -w -s"`

Docker build command example:

`docker build -t karina-custom -f Dockerfile.fast .`
 
 Running version command:

`docker run karina-custom version`

### **Links**

#896 
