### PR TITLE
fix: version command to display release tag #896

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@main
         with:
           fetch-depth: 10
+          all_tags: true
       - name: get-commit-msg
         id: getcommit
         run: |

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 default: build
 NAME:=karina
 
-VERSION_TAG=$(VERSION)-$(shell date +"%Y%m%d%H%M%S")
+VERSION_TAG=$(shell git describe --abbrev=0 --tags)-$(shell date +"%Y%m%d%H%M%S")
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ release: linux darwin compress
 
 .PHONY: build
 build:
-	go build -o ./.bin/$(NAME) -ldflags "-X \"main.version=$(VERSION)\""  main.go
+	go build -o ./.bin/$(NAME) -ldflags "-X \"main.version=$(VERSION_TAG)\""  main.go
 
 
 .PHONY: linux


### PR DESCRIPTION
### Description

_Short summary of what is the issue and the solution._

### Dependencies

- _Ex. Other PRs._

### Breaking Change

- [ ] Yes
- [x] No

### Testing Notes

**What I did:**
_What did you do to validate this PR?_

I build the code using make file and check the checked the version command for output.

**How you can replicate my testing:**
_How can the reviewer validate this PR?_

Build the code using make file, and using the created binary run the version command.
### **Links**

_Issues links or other related resources_

#896 used git describe --abbrev=0 --tags command to get the latest tag for the branch and concatenated it with the existing timestamp, example output: v0.49.0-20210624005637 

review-requested: @moshloop 