### PR TITLE
feat: add seal command for kubeseal

### DIFF
--- a/cmd/seal.go
+++ b/cmd/seal.go
@@ -63,21 +63,17 @@ var Seal = &cobra.Command{
 		p := getPlatform(cmd)
 		flags := []string{
 			getFlagString("format", cmd),
-			getFlagFilePath("sealed-secret-file", cmd),
-			getFlagBool("fetch-cert", cmd),
-			getFlagBool("allow-empty-data", cmd),
-			getFlagBool("validate", cmd),
 			getFlagFilePath("merge-into", cmd),
-			getFlagBool("raw", cmd),
 			getFlagBool("re-encrypt", cmd),
 			getFlagString("name", cmd),
 			getFlagFilePathSlice("from-file", cmd),
 		}
 
 		if !p.SealedSecrets.Disabled && p.SealedSecrets.Certificate != nil {
-			if p.SealedSecrets.Certificate.Cert != "" {
-				flags = append(flags, "--cert", p.SealedSecrets.Certificate.Cert)
+			if p.SealedSecrets.Certificate.Cert == "" {
+				log.Fatalf("Sealed-secrets certificate not provided in config")
 			}
+			flags = append(flags, "--cert", p.SealedSecrets.Certificate.Cert)
 		}
 
 		kubeseal := p.GetBinary("kubeseal")
@@ -91,11 +87,7 @@ var Seal = &cobra.Command{
 
 func init() {
 	Seal.Flags().StringP("format", "o", "yaml", "Output format for sealed secret. Either json or yaml")
-	Seal.Flags().StringP("sealed-secret-file", "w", "", "Sealed-secret (output) file")
-	Seal.Flags().Bool("fetch-cert", false, "Write certificate to stdout. Useful for later use with --cert")
-	Seal.Flags().Bool("validate", false, "Validate that the sealed secret can be decrypted")
 	Seal.Flags().String("merge-into", "", "Merge items from secret into an existing sealed secret file, updating the file in-place instead of writing to stdout.")
-	Seal.Flags().Bool("raw", false, "Encrypt a raw value passed via the --from-* flags instead of the whole secret object")
 	Seal.Flags().Bool("re-encrypt", false, "Re-encrypt the given sealed secret to use the latest cluster key.")
 	Seal.Flags().String("name", "", "Name of the sealed secret (required with --raw and default (strict) scope)")
 	Seal.Flags().StringSlice("from-file", nil, "(only with --raw) Secret items can be sourced from files. Pro-tip: you can use /dev/stdin to read pipe input. This flag tries to follow the same syntax as in kubectl")

--- a/cmd/unseal.go
+++ b/cmd/unseal.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	sealedSecretsNamespace = "sealed-secrets"
+	privateKeyFile         = ".kubeseal.sealed-secrets-key.json"
+)
+
+var Unseal = &cobra.Command{
+	Use:   "unseal",
+	Short: "Unseal a secret using sealed-secrets",
+	Args:  cobra.MinimumNArgs(0),
+	Run: func(cmd *cobra.Command, args []string) {
+		p := getPlatform(cmd)
+		workingDirectory, err := os.Getwd()
+		if err != nil {
+			log.Fatalf("Unable to get the current working directory: %v", err)
+		}
+		flags := []string{
+			"--recovery-unseal",
+			getFlagString("format", cmd),
+			getFlagBool("allow-empty-data", cmd),
+			fmt.Sprintf("--recovery-private-key %s/%s", workingDirectory, privateKeyFile),
+		}
+		if !p.SealedSecrets.Disabled && p.SealedSecrets.Certificate != nil {
+			if p.SealedSecrets.Certificate.Cert != "" {
+				flags = append(flags, "--cert", p.SealedSecrets.Certificate.Cert)
+			}
+		}
+		client, err := p.GetClientset()
+		if err != nil {
+			log.Fatalf("Unable to get Kubernetes client set: %v", err)
+		}
+		secretsInterface := client.CoreV1().Secrets(sealedSecretsNamespace)
+		secrets, err := secretsInterface.List(context.TODO(), metav1.ListOptions{
+			LabelSelector: "sealedsecrets.bitnami.com/sealed-secrets-key=active",
+		})
+		if err != nil {
+			log.Fatalf("Unable to get sealed-secrets active private key: %v", err)
+		}
+		if len(secrets.Items) < 1 {
+			log.Fatalf("No sealed-secrrts active private key set")
+		}
+		secret := secrets.Items[0]
+		// Required because k8s API client does not set it automatically.
+		typeMeta := metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		}
+		secret.TypeMeta = typeMeta
+		file, err := json.Marshal(secret)
+		if err != nil {
+			log.Fatalf("Unable to get sealed-secrets active private key: %v", err)
+		}
+		err = ioutil.WriteFile(privateKeyFile, file, 0600)
+		if err != nil {
+			log.Fatalf("Unable to write sealed-secrets-key to disk: %v", err)
+		}
+		kubeseal := p.GetBinary("kubeseal")
+		flagString := strings.Join(flags, " ")
+		argString := strings.Join(args, " ")
+		if err := kubeseal(flagString + argString); err != nil {
+			os.Remove(privateKeyFile)
+			log.Fatalf("failed to run kubeseal: %v", err)
+		}
+		os.Remove(privateKeyFile)
+	},
+}
+
+func init() {
+	Unseal.Flags().StringP("format", "o", "json", "Output format for sealed secret. Either json or yaml")
+	Unseal.Flags().Bool("allow-empty-data", false, "Allow empty data in the secret object")
+}

--- a/cmd/unseal.go
+++ b/cmd/unseal.go
@@ -3,13 +3,18 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
+	"github.com/flanksource/karina/pkg/ca"
+	"github.com/flanksource/karina/pkg/platform"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -18,51 +23,90 @@ const (
 	privateKeyFile         = ".kubeseal.sealed-secrets-key.json"
 )
 
+func getOfflineCertificate(p *platform.Platform) (corev1.Secret, error) {
+	ca, err := ca.ReadCA(p.SealedSecrets.Certificate)
+	if err != nil {
+		return corev1.Secret{}, err
+	}
+	secret := corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "sealed-secrets-key",
+			Namespace: sealedSecretsNamespace,
+		},
+		Data: ca.AsTLSSecret(),
+	}
+	return secret, nil
+}
+
+func getOnlineCertificate(p *platform.Platform) (corev1.Secret, error) {
+	client, err := p.GetClientset()
+	if err != nil {
+		return corev1.Secret{}, err
+	}
+	secretsInterface := client.CoreV1().Secrets(sealedSecretsNamespace)
+	secrets, err := secretsInterface.List(context.TODO(), metav1.ListOptions{
+		LabelSelector: "sealedsecrets.bitnami.com/sealed-secrets-key=active",
+	})
+	if err != nil {
+		return corev1.Secret{}, err
+	}
+	if len(secrets.Items) < 1 {
+		return corev1.Secret{}, errors.New("no sealed-secrets active private key set")
+	}
+	secret := secrets.Items[0]
+	// Required because k8s API client does not set it automatically.
+	typeMeta := metav1.TypeMeta{
+		Kind:       "Secret",
+		APIVersion: "v1",
+	}
+	secret.TypeMeta = typeMeta
+	return secret, nil
+}
+
 var Unseal = &cobra.Command{
 	Use:   "unseal",
 	Short: "Unseal a secret using sealed-secrets",
 	Args:  cobra.MinimumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		p := getPlatform(cmd)
-		workingDirectory, err := os.Getwd()
+		filePath, err := filepath.Abs(privateKeyFile)
 		if err != nil {
-			log.Fatalf("Unable to get the current working directory: %v", err)
+			log.Fatalf("Unable to resolve file path for %s: %v", privateKeyFile, err)
 		}
 		flags := []string{
 			"--recovery-unseal",
 			getFlagString("format", cmd),
 			getFlagBool("allow-empty-data", cmd),
-			fmt.Sprintf("--recovery-private-key %s/%s", workingDirectory, privateKeyFile),
+			fmt.Sprintf("--recovery-private-key %s", filePath),
 		}
 		if !p.SealedSecrets.Disabled && p.SealedSecrets.Certificate != nil {
 			if p.SealedSecrets.Certificate.Cert != "" {
 				flags = append(flags, "--cert", p.SealedSecrets.Certificate.Cert)
 			}
 		}
-		client, err := p.GetClientset()
-		if err != nil {
-			log.Fatalf("Unable to get Kubernetes client set: %v", err)
+		isOffline, _ := cmd.Flags().GetBool("offline")
+		var secret corev1.Secret
+		if isOffline {
+			if p.SealedSecrets.Certificate.PrivateKey == "" {
+				log.Fatalf("Sealed-secrets private key not provided in config")
+			}
+			secret, err = getOfflineCertificate(p)
+			if err != nil {
+				log.Fatalf("Unable to get sealed-secrets private key from file: %v", err)
+			}
+		} else {
+			secret, err = getOnlineCertificate(p)
+			if err != nil {
+				log.Fatalf("Unable to get sealed-secrets active private key from cluster: %v", err)
+			}
 		}
-		secretsInterface := client.CoreV1().Secrets(sealedSecretsNamespace)
-		secrets, err := secretsInterface.List(context.TODO(), metav1.ListOptions{
-			LabelSelector: "sealedsecrets.bitnami.com/sealed-secrets-key=active",
-		})
-		if err != nil {
-			log.Fatalf("Unable to get sealed-secrets active private key: %v", err)
-		}
-		if len(secrets.Items) < 1 {
-			log.Fatalf("No sealed-secrrts active private key set")
-		}
-		secret := secrets.Items[0]
-		// Required because k8s API client does not set it automatically.
-		typeMeta := metav1.TypeMeta{
-			Kind:       "Secret",
-			APIVersion: "v1",
-		}
-		secret.TypeMeta = typeMeta
 		file, err := json.Marshal(secret)
 		if err != nil {
-			log.Fatalf("Unable to get sealed-secrets active private key: %v", err)
+			log.Fatalf("Unable to get marshal secret to JSON: %v", err)
 		}
 		err = ioutil.WriteFile(privateKeyFile, file, 0600)
 		if err != nil {
@@ -80,6 +124,6 @@ var Unseal = &cobra.Command{
 }
 
 func init() {
-	Unseal.Flags().StringP("format", "o", "json", "Output format for sealed secret. Either json or yaml")
-	Unseal.Flags().Bool("allow-empty-data", false, "Allow empty data in the secret object")
+	Unseal.Flags().StringP("format", "o", "yaml", "Output format for sealed secret. Either json or yaml")
+	Unseal.Flags().Bool("offline", false, "Decrypt with public and private keys on disk and not from the cluster")
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/coreos/prometheus-operator v0.37.0
 	github.com/dghubble/sling v1.3.0
 	github.com/fatih/structs v1.1.0
-	github.com/flanksource/commons v1.5.6
+	github.com/flanksource/commons v1.5.7
 	github.com/flanksource/kommons v0.19.0
 	github.com/flanksource/konfigadm v0.11.0
 	github.com/flanksource/template-operator-library v0.1.6

--- a/go.sum
+++ b/go.sum
@@ -326,6 +326,8 @@ github.com/flanksource/commons v1.4.3/go.mod h1:cGrz4qFi4NrP04vjMxv6DQk0SD0u6nnY
 github.com/flanksource/commons v1.5.1/go.mod h1:v76CUuAsGNgF6MYxQ1XJNwQ4N+WSJbsQ+fTILbP4YP0=
 github.com/flanksource/commons v1.5.6 h1:v56wuTFlFPPn17/ndvStAUGhXO8OHcUDF830TC1civ4=
 github.com/flanksource/commons v1.5.6/go.mod h1:boFAup9GmLcnz0fWQnPV5WVFcHYA7U0aWEA14ww/T/4=
+github.com/flanksource/commons v1.5.7 h1:DmfrpVqxvRoQzhSugDxd/a5C5tQBpRHXeG3dBUNvfkY=
+github.com/flanksource/commons v1.5.7/go.mod h1:boFAup9GmLcnz0fWQnPV5WVFcHYA7U0aWEA14ww/T/4=
 github.com/flanksource/kommons v0.10.0/go.mod h1:7tDF0fPqJeRB1dAUI71Mxmdhd0MYaF3YYHdp4XPgIzM=
 github.com/flanksource/kommons v0.19.0 h1:YN+LRCZdBiqg0PTIEnqkCq9Tx/LRh0ym0+++WWfU63A=
 github.com/flanksource/kommons v0.19.0/go.mod h1:evSkgfTHXqgOwWeM4XPhj43J7xGJcTxHfhJYQchJDp8=

--- a/main.go
+++ b/main.go
@@ -55,6 +55,7 @@ func main() {
 		cmd.Render,
 		cmd.Report,
 		cmd.Rolling,
+		cmd.Seal,
 		cmd.Snapshot,
 		cmd.Status,
 		cmd.Test,

--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ func main() {
 		cmd.TerminateNodes,
 		cmd.TerminateOrphans,
 		cmd.Undelete,
+		cmd.Unseal,
 		cmd.Upgrade,
 		cmd.Vault,
 	)


### PR DESCRIPTION
### Description

Adds support for generating sealedsecrets using kubeseal

### Breaking Change

- [ ] Yes
- [x] No

### Testing Notes

**What I did:**
Replaced `kubeseal` with `karina seal` in calls to create sealedsecrets

### **Links**

Fixes: #645 
