### PR TITLE
fix: correct external-dns rbac

### DIFF
--- a/manifests/external-dns.yaml
+++ b/manifests/external-dns.yaml
@@ -7,7 +7,8 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: platform-system
+  name: external-dns
+  namespace: platform-system
 rules:
   - apiGroups: [""]
     resources: ["services", "endpoints", "pods"]
@@ -17,7 +18,7 @@ rules:
     verbs: ["get", "watch", "list"]
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["list"]
+    verbs: ["list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
### Description

Fix rbac config that prevents external-dns from starting correctly

### Dependencies

- _Ex. Other PRs._

### Breaking Change

- [ ] Yes
- [x] No

### Testing Notes

Inserted updated clusterrole into faulty cluster

### **Links**

_Issues links or other related resources_
