### PR TITLE
fix: make built-in dashboard names DNS1192 compatible

### DIFF
--- a/pkg/phases/monitoring/monitoring.go
+++ b/pkg/phases/monitoring/monitoring.go
@@ -169,7 +169,7 @@ func deployDashboards(p *platform.Platform) error {
 			return errors.Wrapf(err, "failed to template: %v", name)
 		}
 
-		if err := DeployDashboard(p, "Built-In", rootPath+"/"+name, contents); err != nil {
+		if err := DeployDashboard(p, "Built-In", kommons.GetDNS1192Name(rootPath+"/"+name), contents); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
### Description

Adding a missing string conversion call on dynamic grafana dashboard names

### Dependencies

- _Ex. Other PRs._

### Breaking Change

- [ ] Yes
- [X] No

### Testing Notes

deployed monitoring to test cluster

### **Links**

_Issues links or other related resources_
