### PR TITLE
fix: create elasic-webhook-server certificate

### DIFF
--- a/manifests/elasticsearch.yaml
+++ b/manifests/elasticsearch.yaml
@@ -120,4 +120,23 @@ spec:
                 port:
                   number: 5601
             pathType: ImplementationSpecific
-
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  annotations:
+    cert-manager.io/allow-direct-injection: "true"
+  name: elastic-webhook-server
+  namespace: elastic-system
+spec:
+  dnsNames:
+    - elastic-webhook-server
+    - elastic-webhook-server.elastic-system.svc
+    - elastic-webhook-server.elastic-system.svc.cluster.local
+  issuerRef:
+    kind: ClusterIssuer
+    name: default-issuer
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  secretName: elastic-webhook-server-cert


### PR DESCRIPTION
### Description

Elastic operator fails to start looking for it

### Breaking Change

- [ ] Yes
- [x] No

### Testing Notes

**What I did:**
Deployed in kind and BCB clusters