### PR TITLE
feat: add flag to prevent ingress cluster issuer being created

### DIFF
--- a/pkg/phases/certmanager/install.go
+++ b/pkg/phases/certmanager/install.go
@@ -109,8 +109,10 @@ func Install(p *platform.Platform) error {
 		return nil
 	}
 
-	if err := createIngressCA(p); err != nil {
-		return err
+	if !p.CertManager.ExternalCA {
+		if err := createIngressCA(p); err != nil {
+			return err
+		}
 	}
 
 	ca, err := p.CreateOrGetWebhookCertificate(Namespace, WebhookService)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -35,6 +35,8 @@ type CertManager struct {
 	// Details of a Letsencrypt issuer to use for signing ingress certificates
 	Letsencrypt     *LetsencryptIssuer `yaml:"letsencrypt,omitempty" json:"letsencrypt,omitempty"`
 	DefaultIssuerCA string             `yaml:"-" json:"-"`
+	// Set to true if ingress CA will be configured via kustomise or similar
+	ExternalCA 		bool			   `yaml:"externalCA,omitempty" json:"externalCA,omitempty"`
 }
 
 type VaultClient struct {


### PR DESCRIPTION
### Description

In cases where complex clusterissuer specs need to be constructed outside of karina and managed via kustomise, the current behaviour creates conflicting issuer configs.  Add a config flag to prevent an ingress clusterissuer being created in such scenarios


### Breaking Change

- [ ] Yes
- [x] No

