### PR TITLE
feat: add gitlab connector to dex

### DIFF
--- a/manifests/dex.cfg
+++ b/manifests/dex.cfg
@@ -55,6 +55,32 @@ connectors:
         {{ end }}
       {{ end }}
   {{ end }}
+  {{ if index .dex "gitlab" }}
+  - type: gitlab
+    # Required field for connector id.
+    id: gitlab
+    # Required field for connector name.
+    name: GitLab
+    config:
+      # optional, default = https://gitlab.com
+      baseURL: https://gitlab.com
+      # Credentials can be string literals or pulled from the environment.
+      clientID: $GITLAB_APPLICATION_ID
+      clientSecret: $GITLAB_CLIENT_SECRET
+      redirectURI: https://dex.{{.domain}}/callback
+      # Optional groups whitelist, communicated through the "groups" scope.
+      # If `groups` is omitted, all of the user's GitLab groups are returned when the groups scope is present.
+      # If `groups` is provided, this acts as a whitelist - only the user's GitLab groups that are in the configured `groups` below will go into the groups claim.  Conversely, if the user is not in any of the configured `groups`, the user will not be authenticated.
+      if {{ index .dex.gitlab.groups }}
+      groups:
+      {{ range .dex.gitlab.groups }}
+      - {{ . }}
+      {{ end }}
+      {{ end }}
+      # flag which will switch from using the internal GitLab id to the users handle (@mention) as the user id.
+      # It is possible for a user to change their own user name but it is very rare for them to do so
+      useLoginAsID: false
+  {{ end }}
   {{ if index . "ldap" }}
   - type: ldap
     id: ldap

--- a/manifests/dex.yaml
+++ b/manifests/dex.yaml
@@ -46,6 +46,9 @@ spec:
                 name: github-account
                 optional: true
             - secretRef:
+                name: gitlab-account
+                optional: true
+            - secretRef:
                 name: ldap-account
                 optional: true
       volumes:

--- a/pkg/phases/dex/install.go
+++ b/pkg/phases/dex/install.go
@@ -56,6 +56,14 @@ func Install(platform *platform.Platform) error {
 			return fmt.Errorf("install: failed to create/update github secret: %v", err)
 		}
 	}
+	if platform.Dex.Gitlab.ApplicationID != "" {
+		if err := platform.CreateOrUpdateSecret("gitlab-account", Namespace, map[string][]byte{
+			"GITLAB_APPLICATION_ID": []byte(platform.Dex.Gitlab.ApplicationID),
+			"GITLAB_CLIENT_SECRET":  []byte(platform.Dex.Gitlab.ClientSecret),
+		}); err != nil {
+			return fmt.Errorf("install: failed to create/update gitlab secret: %v", err)
+		}
+	}
 	if !platform.Ldap.Disabled {
 		if err := platform.CreateOrUpdateSecret("ldap-account", Namespace, map[string][]byte{
 			"AD_PASSWORD": []byte(platform.Ldap.Password),

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -452,6 +452,13 @@ type Dex struct {
 	XDisabled `yaml:",inline" json:",inline"`
 	Google    GoogleOIDC `yaml:"google,omitempty" json:"google,omitempty"`
 	Github    GithubOIDC `yaml:"github,omitempty" json:"github,omitempty"`
+	Gitlab    GitlabOIDC `yaml:"gitlab,omitempty" json:"gitlab,omitempty"`
+}
+
+type GitlabOIDC struct {
+	ApplicationID string   `yaml:"applicationID,omitempty" json:"applicationID,omitempty"`
+	ClientSecret  string   `yaml:"clientSecret,omitempty" json:"clientSecret,omitempty"`
+	Groups        []string `yaml:"groups,omitempty" json:"groups,omitempty"`
 }
 
 type GithubOIDC struct {


### PR DESCRIPTION
### Description

Adds gitlab connector config to dex configmap, along with requisite karinaConfig entries and secret creation in dex install phase.

### Dependencies

NA

### Breaking Change

- [ ] Yes
- [x] No
