### PR TITLE
fix: correct index use in dex config

### DIFF
--- a/manifests/dex.cfg
+++ b/manifests/dex.cfg
@@ -42,7 +42,7 @@ connectors:
       clientID: $GITHUB_CLIENT_ID
       clientSecret: $GITHUB_CLIENT_SECRET
       redirectURI: https://dex.{{.domain}}/callback
-      {{ if index .dex.github.orgs }}
+      {{ if index .dex.github "orgs" }}
       orgs:
         {{ range .dex.github.orgs }}
         - name: {{ .name }}
@@ -71,7 +71,7 @@ connectors:
       # Optional groups whitelist, communicated through the "groups" scope.
       # If `groups` is omitted, all of the user's GitLab groups are returned when the groups scope is present.
       # If `groups` is provided, this acts as a whitelist - only the user's GitLab groups that are in the configured `groups` below will go into the groups claim.  Conversely, if the user is not in any of the configured `groups`, the user will not be authenticated.
-      {{ if index .dex.gitlab.groups }}
+      {{ if index .dex.gitlab "groups" }}
       groups:
         {{- range .dex.gitlab.groups }}
         - {{ . }}


### PR DESCRIPTION
### Description

Fixes errors like 

```
time=2021-11-18T07:31:00Z level=fatal msg=Failed to deploy bootstrap: install: failed to template configmap: error executing template issuer: https://dex.{{.domain}}: template: :74:12: executing "" at <index .dex.gitlab.groups>: error calling index: index of untyped nil
```

### Breaking Change

- [ ] Yes
- [x] No

### Testing Notes

**What I did:**
Tested in kind