### PR TITLE
Autoscaler compatibility

### DIFF
--- a/manifests/canary-checker.yaml
+++ b/manifests/canary-checker.yaml
@@ -152,6 +152,7 @@ spec:
         com.flanksource.infra.logs/processors.1.drop_event.when.contains.message: '[pod/canary] request completed with 503, expected [200 201 202], retrying'
         com.flanksource.infra.logs/processors.2.drop_event.when.contains.message: Requeue reconciliation
         com.flanksource.infra.logs/processors.3.drop_event.when.contains.message: Successfully Reconciled
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         control-plane: canary-checker
     spec:

--- a/manifests/flux-v2.yaml
+++ b/manifests/flux-v2.yaml
@@ -251,6 +251,7 @@ spec:
       annotations:
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: helm-controller
     spec:
@@ -324,6 +325,7 @@ spec:
       annotations:
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: kustomize-controller
     spec:
@@ -399,6 +401,7 @@ spec:
       annotations:
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: notification-controller
     spec:
@@ -477,6 +480,7 @@ spec:
       annotations:
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: source-controller
     spec:

--- a/manifests/monitoring/kube-prometheus.yaml
+++ b/manifests/monitoring/kube-prometheus.yaml
@@ -23,6 +23,7 @@ spec:
       reload/all: "true"
       com.flanksource.infra.logs/processors.0.drop_event.when.contains.message: level=debug
       com.flanksource.infra.logs/processors.1.drop_event.when.contains.message: component=cluster
+      "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
   alertmanagerConfigSelector:
     matchLabels:
       alertmanagerConfig: main


### PR DESCRIPTION
### Description

Adds an annotation to pods that are usually deployed with an emptyDir to allow them to relocated by cluster autoscalers

### Dependencies

NA

### Breaking Change

- [ ] Yes
- [x] No
