### PR TITLE
Feat: add alerting hook for nginx specific alerts

### DIFF
--- a/manifests/monitoring/nginx-alerts.yaml.raw
+++ b/manifests/monitoring/nginx-alerts.yaml.raw
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: prometheus-nginx-rules
+  namespace: monitoring
+spec:
+  groups:
+    - name: nginx-alert.rules
+      rules:
+        - alert: NginxIngressConfigError
+          annotations:
+            message: Nginx Ingress controller has encountered errors parsing config
+          expr: |
+            sum(rate(nginx_ingress_controller_errors[1m])) > 0
+          for: 1m
+          labels:
+            severity: critical

--- a/manifests/nginx.yaml
+++ b/manifests/nginx.yaml
@@ -537,7 +537,6 @@ spec:
       protocol: TCP
   selector:
     app: ingress-nginx
-
 ---
 {{- if not .monitoring.disabled }}
 apiVersion: monitoring.coreos.com/v1

--- a/pkg/phases/nginx/install.go
+++ b/pkg/phases/nginx/install.go
@@ -133,6 +133,12 @@ func Install(platform *platform.Platform) error {
 	if err := platform.ApplySpecs(v1.NamespaceAll, "nginx.yaml"); err != nil {
 		return err
 	}
+	// nginx alerts live in a separate manifest as alert syntax often cannot be templated
+	if !platform.Monitoring.IsDisabled() {
+		if err := platform.ApplySpecs("monitoring/nginx-alerts.yaml.raw"); err != nil {
+			return err
+		}
+	}
 	return nil
 	// wait for the webhook to come up ready as otherwise subsequent ingress
 	// creations will fail due to the validating webhook


### PR DESCRIPTION
### Description

Adds a new manifest and corresponding install phase actions to deploy alerts specific to the nginx ingress controller

### Dependencies

NA

### Breaking Change

- [ ] Yes
- [x] No
