### PR TITLE
Autoscaler compatibility

### DIFF
--- a/manifests/elasticsearch.yaml
+++ b/manifests/elasticsearch.yaml
@@ -18,6 +18,11 @@ spec:
         xpack.security.authc.anonymous.roles: fluentd
       podTemplate:
         spec:
+          {{- if (eq .elasticsearch.persistence.enabled true) }}
+          metadata:
+            annotations:
+              cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+          {{- end}}
           containers:
             - name: elasticsearch
               env:

--- a/manifests/sealed-secrets.yaml
+++ b/manifests/sealed-secrets.yaml
@@ -29,7 +29,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations: {}
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         name: sealed-secrets-controller
     spec:


### PR DESCRIPTION
### Description

Adds eviction annotations to pods with emptydir mounts that prevent them from being moved by autoscaler directives

### Dependencies
NA

### Breaking Change

- [ ] Yes
- [x] No