### PR TITLE
chore: bump kube-rbac-proxy versions

### DIFF
--- a/manifests/logs-exporter.yaml
+++ b/manifests/logs-exporter.yaml
@@ -124,7 +124,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.11.0
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/manifests/monitoring/kube-state-metrics.yaml
+++ b/manifests/monitoring/kube-state-metrics.yaml
@@ -126,7 +126,7 @@ spec:
             - --secure-listen-address=:8443
             - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
             - --upstream=http://127.0.0.1:8081/
-          image: quay.io/coreos/kube-rbac-proxy:v0.4.1
+          image: quay.io/brancz/kube-rbac-proxy:v0.11.0
           name: kube-rbac-proxy-main
           ports:
             - containerPort: 8443
@@ -142,7 +142,7 @@ spec:
             - --secure-listen-address=:9443
             - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
             - --upstream=http://127.0.0.1:8082/
-          image: quay.io/coreos/kube-rbac-proxy:v0.4.1
+          image: quay.io/brancz/kube-rbac-proxy:v0.11.0
           name: kube-rbac-proxy-self
           ports:
             - containerPort: 9443

--- a/manifests/monitoring/node-exporter.yaml
+++ b/manifests/monitoring/node-exporter.yaml
@@ -86,7 +86,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-          image: bitname/kube-rbac-proxy:v0.12.0
+          image: quay.io/brancz/kube-rbac-proxy:v0.11.0
           imagePullPolicy: IfNotPresent
           name: kube-rbac-proxy
           ports:

--- a/manifests/monitoring/node-exporter.yaml
+++ b/manifests/monitoring/node-exporter.yaml
@@ -86,7 +86,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.podIP
-          image: quay.io/coreos/kube-rbac-proxy:v0.4.1
+          image: bitname/kube-rbac-proxy:v0.12.0
           imagePullPolicy: IfNotPresent
           name: kube-rbac-proxy
           ports:


### PR DESCRIPTION
### Description

Older kube-rbac-proxy images use the deprecated authentication/v1beta api call rather than v1.  Newer image version are needed for kubernetes 1.22

### Dependencies

NA

### Breaking Change

- [ ] Yes
- [x] No

### Testing Notes

Verified Prometheus is able scrape node-exporter pods with the new sidecar image
