### PR TITLE
chore: update default registry for sealed-secrets-controller

### DIFF
--- a/manifests/sealed-secrets.yaml
+++ b/manifests/sealed-secrets.yaml
@@ -35,7 +35,7 @@ spec:
         name: sealed-secrets-controller
     spec:
       containers:
-        - image: quay.io/bitnami/sealed-secrets-controller:{{ .sealedSecrets.version | default "na" }}
+        - image: docker.io/bitnami/sealed-secrets-controller:{{ .sealedSecrets.version | default "na" }}
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
### Description

sealed secrets controller is no longer hosted on quay and attempting to access to the old url gives a 403 error.

update manifest to use the new default registry at docker.io

### Dependencies
NA

### Breaking Change

- [ ] Yes
- [x] No
