### PR TITLE
chore: update webhook apiVersion for 1.22

### DIFF
--- a/config/operator/default/webhookcainjection_patch.yaml
+++ b/config/operator/default/webhookcainjection_patch.yaml
@@ -1,13 +1,13 @@
 # This patch add annotation to admission webhook config and
 # the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration

--- a/manifests/kpack.yaml
+++ b/manifests/kpack.yaml
@@ -415,7 +415,7 @@ spec:
         kubernetes.io/os: linux
       serviceAccountName: webhook
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: defaults.webhook.kpack.io
@@ -430,7 +430,7 @@ webhooks:
   name: defaults.webhook.kpack.io
   sideEffects: None
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.kpack.io

--- a/manifests/opa-kubemgmt.yaml
+++ b/manifests/opa-kubemgmt.yaml
@@ -214,7 +214,7 @@ data:
     }
 ---
 kind: ValidatingWebhookConfiguration
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 metadata:
   name: opa-validating-webhook
   annotations:

--- a/manifests/tekton.yaml
+++ b/manifests/tekton.yaml
@@ -384,7 +384,7 @@ metadata:
     pipeline.tekton.dev/release: devel
 # The data is populated at install time.
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.pipeline.tekton.dev
@@ -402,7 +402,7 @@ webhooks:
     sideEffects: None
     name: validation.webhook.pipeline.tekton.dev
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: webhook.pipeline.tekton.dev
@@ -420,7 +420,7 @@ webhooks:
     sideEffects: None
     name: webhook.pipeline.tekton.dev
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.pipeline.tekton.dev


### PR DESCRIPTION
### Description

Update deprecated beta1 webhook apis to v1

### Dependencies

NA

### Breaking Change

- [ ] Yes
- [x] No