### PR TITLE
fix: updated nginx rbac to accountfor change in leadership cm between…

### DIFF
--- a/manifests/nginx.yaml
+++ b/manifests/nginx.yaml
@@ -93,6 +93,7 @@ rules:
       - configmaps
     resourceNames:
       - "ingress-controller-leader-nginx"
+      - "ingress-controller-leader"
     verbs:
       - get
       - update


### PR DESCRIPTION
… v0.xand v1

### Description

Name of leadership cm changed between nginx v0 and v1.  Change manifest rbac to give nginx permission to access both

### Dependencies

NA

### Breaking Change

- [ ] Yes
- [x] No

