### PR TITLE
Version bumps

### DIFF
--- a/manifests/monitoring/grafana-operator.yaml
+++ b/manifests/monitoring/grafana-operator.yaml
@@ -337,7 +337,7 @@ spec:
         - --metrics-bind-address=127.0.0.1:8080
         - --zap-log-level=error
         - --grafana-image=docker.io/grafana/grafana
-        - --grafana-image-tag={{.monitoring.grafana.version | default "8.1.1" }}
+        - --grafana-image-tag={{.monitoring.grafana.version | default "8.5.5" }}
         command:
         - /manager
         env:
@@ -349,7 +349,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: quay.io/grafana-operator/grafana-operator:v4.2.0
+        image: quay.io/grafana-operator/grafana-operator:v4.4.1
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/manifests/monitoring/kube-state-metrics.yaml
+++ b/manifests/monitoring/kube-state-metrics.yaml
@@ -158,7 +158,7 @@ spec:
             - --port=8081
             - --telemetry-host=127.0.0.1
             - --telemetry-port=8082
-          image: quay.io/coreos/kube-state-metrics:v1.8.0
+          image: quay.io/coreos/kube-state-metrics:v2.5.0
           name: kube-state-metrics
           resources:
             limits:


### PR DESCRIPTION
### Description

Bump kube-state-metrics version for 1.22 compatibility - older version has lots of failed calls to deprecated api endpoints
Bump grafana and grafana operator versions - hitting a bug in some environments where dashboards are constantly being reloaded because of a comms issue between the two

### Dependencies
NA

### Breaking Change

- [ ] Yes
- [x] No
