### PR TITLE
fix: update kube-state-metric registry location

### DIFF
--- a/manifests/monitoring/kube-state-metrics.yaml
+++ b/manifests/monitoring/kube-state-metrics.yaml
@@ -158,7 +158,7 @@ spec:
             - --port=8081
             - --telemetry-host=127.0.0.1
             - --telemetry-port=8082
-          image: quay.io/coreos/kube-state-metrics:v2.5.0
+          image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
           name: kube-state-metrics
           resources:
             limits:


### PR DESCRIPTION
### Description

Kube state metrics project is now part of kubernetes and is found in a different image registry

### Dependencies
NA

### Breaking Change

- [ ] Yes
- [x] No