### PR TITLE
fix: add rbac needed for eck 2.3

### DIFF
--- a/manifests/eck.yaml
+++ b/manifests/eck.yaml
@@ -199,6 +199,17 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
### Description

Add an rbac entry for the new leadership election mechanism in eck 2.3

### Dependencies

NA

### Breaking Change

- [ ] Yes
- [x] No

### Testing Notes

edited rbac in cluster, eck operator stopped error loop

