### PR TITLE
fix: remove old canary-checker ingress

### DIFF
--- a/pkg/phases/canary/deploy.go
+++ b/pkg/phases/canary/deploy.go
@@ -17,5 +17,10 @@ func Deploy(p *platform.Platform) error {
 		return nil
 	}
 
+	err := p.DeleteByKind("Ingress", "platform-system", "canary-checker")
+	if err != nil {
+		p.Warnf("failed to delete old ingress: ", err)
+	}
+
 	return p.ApplySpecs(v1.NamespaceAll, specs...)
 }


### PR DESCRIPTION
Removes the old canary-checker ingress if it exists