### PR TITLE
Disable deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,7 +28,6 @@ linters:
     - misspell
     - nakedret
     - revive
-    - rowserrcheck
     - staticcheck
     - stylecheck
     - typecheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - errcheck
@@ -31,13 +30,11 @@ linters:
     - revive
     - rowserrcheck
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
 
 linters-settings:

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -156,11 +156,11 @@ func init() {
 	}
 
 	aliases := map[string][]string{
-		"bootstrap": []string{"cni", "csi", "base", "cloud", "cert-manager", "nginx", "minio", "template-operator", "postgres-operator"},
-		"cni":       []string{"calico", "antrea"},
-		"csi":       []string{"s3", "nfs", "local-path"},
-		"cloud":     []string{"vsphere"},
-		"stubs":     []string{"apacheds", "minio"},
+		"bootstrap": {"cni", "csi", "base", "cloud", "cert-manager", "nginx", "minio", "template-operator", "postgres-operator"},
+		"cni":       {"calico", "antrea"},
+		"csi":       {"s3", "nfs", "local-path"},
+		"cloud":     {"vsphere"},
+		"stubs":     {"apacheds", "minio"},
 	}
 	tests := map[string]TestFn{
 		"antrea":             antrea.Test,

--- a/pkg/api/calico/bgpconfig.go
+++ b/pkg/api/calico/bgpconfig.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/api/calico/bgppeer.go
+++ b/pkg/api/calico/bgppeer.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/api/calico/ippool.go
+++ b/pkg/api/calico/ippool.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/api/kubeadm.go
+++ b/pkg/api/kubeadm.go
@@ -90,7 +90,7 @@ type JoinControlPlane struct {
 	CertificateKey string `yaml:"certificateKey,omitempty"`
 }
 
-//nolint: revive
+// nolint: revive
 type APIEndpoint struct {
 	// AdvertiseAddress sets the IP address for the API server to advertise.
 	AdvertiseAddress string `yaml:"advertiseAddress,omitempty"`

--- a/pkg/api/postgres/types.go
+++ b/pkg/api/postgres/types.go
@@ -22,9 +22,9 @@ const (
 )
 
 const (
-	//serviceNameMaxLength   = 63
-	clusterNameMaxLength   = serviceNameMaxLength - len("-repl") // nolint: unused, varcheck, deadcode
-	serviceNameRegexString = `^[a-z]([-a-z0-9]*[a-z0-9])?$`      // nolint: unused, varcheck, deadcode
+	serviceNameMaxLength   = 63                                  // nolint: unused
+	clusterNameMaxLength   = serviceNameMaxLength - len("-repl") // nolint: unused
+	serviceNameRegexString = `^[a-z]([-a-z0-9]*[a-z0-9])?$`      // nolint: unused
 )
 
 func NewPostgresql(name string) *Postgresql {

--- a/pkg/api/postgres/types.go
+++ b/pkg/api/postgres/types.go
@@ -22,7 +22,7 @@ const (
 )
 
 const (
-	serviceNameMaxLength   = 63
+	//serviceNameMaxLength   = 63
 	clusterNameMaxLength   = serviceNameMaxLength - len("-repl") // nolint: unused, varcheck, deadcode
 	serviceNameRegexString = `^[a-z]([-a-z0-9]*[a-z0-9])?$`      // nolint: unused, varcheck, deadcode
 )

--- a/pkg/api/postgres/types.go
+++ b/pkg/api/postgres/types.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// 	ClusterStatusUnknown etc : status of a Postgres cluster known to the operator
+// ClusterStatusUnknown etc : status of a Postgres cluster known to the operator
 const (
 	ClusterStatusUnknown      = ""
 	ClusterStatusCreating     = "Creating"
@@ -233,7 +233,7 @@ type Patroni struct {
 	SynchronousModeStrict bool                         `json:"synchronous_mode_strict"`
 }
 
-//StandbyCluster
+// StandbyCluster
 type StandbyDescription struct {
 	S3WalPath string `json:"s3_wal_path,omitempty"`
 }
@@ -495,5 +495,5 @@ type OperatorConfigurationData struct {
 	ConnectionPooler           ConnectionPoolerConfiguration      `json:"connection_pooler"`
 }
 
-//Duration shortens this frequently used name
+// Duration shortens this frequently used name
 type Duration time.Duration

--- a/pkg/phases/harbor/install.go
+++ b/pkg/phases/harbor/install.go
@@ -107,7 +107,7 @@ func Deploy(p *platform.Platform) error {
 
 	if !p.ApplyDryRun {
 		chartSecret := map[string][]byte{
-			"CACHE_REDIS_PASSWORD": []byte{},
+			"CACHE_REDIS_PASSWORD": {},
 		}
 		if p.Harbor.ChartPVC == "" {
 			chartSecret["AWS_SECRET_ACCESS_KEY"] = []byte(p.Harbor.S3.SecretKey)
@@ -117,7 +117,7 @@ func Deploy(p *platform.Platform) error {
 		}
 
 		if err := p.CreateOrUpdateSecret("harbor-trivy", Namespace, map[string][]byte{
-			"gitHubToken": []byte{},
+			"gitHubToken": {},
 			"redisURL":    []byte("redis://harbor-redis:6379/4"),
 		}); err != nil {
 			return err

--- a/pkg/phases/konfigadm.go
+++ b/pkg/phases/konfigadm.go
@@ -123,6 +123,7 @@ func CreateWorker(nodegroup string, platform *platform.Platform) (*konfigadm.Con
 // baseKonfig generates a base konfigadm configuration.
 // It copies in the required environment variables and
 // initial commands.
+//
 //nolint:unparam
 func baseKonfig(initialKonfigadmFile string, platform *platform.Platform) (*konfigadm.Config, error) {
 	var cfg *konfigadm.Config

--- a/pkg/provision/status.go
+++ b/pkg/provision/status.go
@@ -139,15 +139,15 @@ func gb(bytes int64) string {
 	return fmt.Sprintf("%d", bytes/1024/1024/1024)
 }
 
-func size(bytes int64) string {
-	if bytes > 1024*1024*1024 {
-		return fmt.Sprintf("%.00d gb", bytes/1024/1024/1024)
-	}
-	if bytes > 1024*1024 {
-		return fmt.Sprintf("%.00d mb", bytes/1024/1024)
-	}
-	if bytes > 1024 {
-		return fmt.Sprintf("%.00d kb", bytes/1024)
-	}
-	return fmt.Sprintf("%.00d bytes", bytes)
-}
+//func size(bytes int64) string {
+//	if bytes > 1024*1024*1024 {
+//		return fmt.Sprintf("%.00d gb", bytes/1024/1024/1024)
+//	}
+//	if bytes > 1024*1024 {
+//		return fmt.Sprintf("%.00d mb", bytes/1024/1024)
+//	}
+//	if bytes > 1024 {
+//		return fmt.Sprintf("%.00d kb", bytes/1024)
+//	}
+//	return fmt.Sprintf("%.00d bytes", bytes)
+//}


### PR DESCRIPTION
### Description

linting job is broken due to deprecated linters and some linting errors - fixed


### Breaking Change

- [ ] Yes
- [x] No

### Testing Notes

verified golangci-lint locally
