### PR TITLE
feat: do not delete flux when disabled

### DIFF
--- a/pkg/phases/flux/fluxv2.go
+++ b/pkg/phases/flux/fluxv2.go
@@ -10,7 +10,7 @@ const Namespace = "flux-system"
 
 func InstallV2(p *platform.Platform) error {
 	if p.Flux == nil || !p.Flux.Enabled {
-		return p.DeleteSpecs(Namespace, "flux.yaml")
+		return nil
 	}
 
 	if err := p.CreateOrUpdateNamespace(Namespace, nil, nil); err != nil {


### PR DESCRIPTION
This allows us to deploy from upstream without Karina deleting it after the fact. With things moving out of Karina, this should probably be the standard approach