### PR TITLE
feat: do not delete canary-checker when disabled

### DIFF
--- a/pkg/phases/canary/deploy.go
+++ b/pkg/phases/canary/deploy.go
@@ -10,10 +10,6 @@ var specs = []string{"canary-checker.yaml", "canary-checker-monitoring.yaml.raw"
 // Deploy deploys the canary-checker into the monitoring namespace
 func Deploy(p *platform.Platform) error {
 	if p.CanaryChecker.IsDisabled() {
-		if err := p.DeleteSpecs(v1.NamespaceAll, specs...); err != nil {
-			p.Errorf("failed to delete specs: %v", err)
-		}
-
 		return nil
 	}
 


### PR DESCRIPTION
This allows us to deploy from upstream without Karina deleting it after the fact