### PR TITLE
feat: do not delete sealed-secrets on disable

### DIFF
--- a/pkg/phases/sealedsecrets/install.go
+++ b/pkg/phases/sealedsecrets/install.go
@@ -28,9 +28,6 @@ var (
 
 func Install(platform *platform.Platform) error {
 	if platform.SealedSecrets.IsDisabled() {
-		if err := platform.DeleteSpecs(Namespace, "sealed-secrets.yaml"); err != nil {
-			platform.Warnf("failed to delete specs: %v", err)
-		}
 		return nil
 	}
 


### PR DESCRIPTION
This ensures that we can replace it with upstream Helm chart without Karina deleting things